### PR TITLE
Docker 를 사용한 로컬 개발환경을 사용할 수 있도록 구성합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+
+# for docker
+
+# mariadb data
+/mariadb_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y software-properties-common
+RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
+
+RUN apt-get update -y && apt-get install -y nginx supervisor curl vim
+RUN apt-get update -y && apt-get install -y php8.1 \
+    php8.1-fpm \
+    php8.1-common \
+    php8.1-mysql \
+    php8.1-gmp \
+    php8.1-ldap \
+    php8.1-curl \
+    php8.1-intl \
+    php8.1-mbstring \
+    php8.1-xmlrpc \
+    php8.1-gd \
+    php8.1-bcmath \
+    php8.1-xml \
+    php8.1-cli \
+    php8.1-memcache \
+    php8.1-redis \
+    php8.1-zip
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+#Mine    
+
+#Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN composer self-update
+
+WORKDIR /var/www/html
+COPY . .
+RUN composer install
+
+COPY ./conf/nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 80
+EXPOSE 443
+#EXPOSE 22
+#EXPOSE 9000
+
+CMD ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,21 @@
+server {
+        listen 80;
+        root /var/www/html/public;
+        index index.html index.htm index.php;
+
+        server_name localhost;
+
+    	error_log  /var/log/nginx/error.log;
+	    access_log /var/log/nginx/access.log;
+
+
+        location ~ \.php$ {
+                try_files $uri =404;
+                fastcgi_split_path_info ^(.+\.php)(/.+)$;
+                fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+                fastcgi_index index.php;
+                include fastcgi_params;
+                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                fastcgi_param PATH_INFO $fastcgi_path_info;
+        }
+}

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,0 +1,25 @@
+[supervisord]
+user = root
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
+
+[program:nginx]
+command=nginx -g "daemon off;"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+
+[program:php-fpm]
+command=/bin/bash -c "mkdir -p /var/run/php && php-fpm8.1 --nodaemonize --fpm-config /etc/php/8.1/fpm/php-fpm.conf"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+
+services:
+    ubuntu:
+        container_name: nginx_php81
+        build:
+            dockerfile: Dockerfile
+        stdin_open: true
+        tty: true
+        volumes:
+            - .:/var/www/html
+        ports:
+            - "80:80"
+            - "443:443"
+    db:
+        image: mariadb:latest
+        container_name: mariadb
+        restart: always
+        environment:
+            MYSQL_DATABASE: memorial
+            MYSQL_USER: memorial
+            MYSQL_PASSWORD: memorial
+            MYSQL_ROOT_PASSWORD: memorial
+        volumes:
+            - ./mariadb_data:/var/lib/mysql    
+        ports:
+            - "3306:3306"


### PR DESCRIPTION
## 배경
- 로컬 개발환경과 `AWS EC2` `OS` 차이로 개발환경을 일치할 필요가 있습니다. 
- 아직 프로젝트 초기 단계라 `EC2` 에 `Docker` 를 사용하지 않지만 추후 서비스 규모가 커지면 사용할 수 있다고 판단되어 `Docker` 를 바로 사용할 수 있도록 프로젝트에 추가하려고 합니다.

## 작업내용
- gitignore 에 docker 사용시 생성되는 데이터(mariadb) 폴더 및 파일을 추가하였습니다.
- `nginx`, `supervisord` config 파일을 생성하고 docker 에서 사용할 수 있도록 하였습니다.
- docker-compose.yml 파일을 추가하고, `ubuntu` 에  php8.1-fpm 을 설치하고, nginx 와 supervisord 설정이 되도록 작업하였습니다.

## 테스트방법
- 로컬 환경에서 docker app 설치후 아래 명령어를 순차적으로 실행합니다.
```
$> docker-compose build --no-cache
$> docker-compose up -d
```

```
$> docker-compose down
$> docker system prune < 필요시
```

## 리뷰노트
- 아주 간만에 docker 를 사용하다보니 잘 된거지 모르겠어요. 일단 제 피씨에서는 아래처럼 라라벨이 잘 나오네요!

## 스크린샷
![스크린샷 2023-11-27 오전 12 43 32](https://github.com/Genithlabs/memorial-admin-api/assets/360568/709fb702-2a36-4717-81d8-9c78444c3a9e)
