### PR TITLE
회원 테이블 명을 대문자에서 소문자를 참조하도록 수정합니다.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,7 +12,7 @@ class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 
-    protected $table = "MM_USERS";
+    protected $table = "mm_users";
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2023_12_15_165339_create_mm_users_table.php
+++ b/database/migrations/2023_12_15_165339_create_mm_users_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('MM_USERS', function (Blueprint $table) {
+        Schema::create('mm_users', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->charset = 'utf8mb4';
             $table->bigIncrements('id');
@@ -39,6 +39,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('MM_USERS');
+        Schema::dropIfExists('mm_users');
     }
 };


### PR DESCRIPTION
## 배경
- `Migrate` 생성시 테이블명을 모두 대문자로 생성하도록 정의했는데, 스키마에 모두 소문자로 되어 있어서 변경이 필요합니다.
- [스키마](https://www.notion.so/mininc/DB-Schema-e9329ffca70f41989c74a2ff121b7c01?pvs=4)

## 작업내용
- `Miragation` 파일에 대문자 테이블명을 모두 소문자로 변경하였습니다.
- `User` 모델에서 대문자 테이블명을 모두 소문자로 변경하였습니다.

## 테스트 방법
- 이 PR 이 머지되면 `/api/user/register` API 를 통해 회원가입을 진행할 수 있습니다.

## 리뷰노트
- `AWS EC2` 에 `git` `clone` 을 위해 기존 `documentRoot` 를 변경하였습니다. 
```
기존 : /var/www/footprint
변경 : /var/www/footprint/memorial-adminapi
```
- 변경된 경로에 맞춰 `nginx` 의 설정값도 변경하였습니다.

