### PR TITLE
로그인 `API` 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -6,8 +6,10 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
 use Laravel\Passport\Client;
 use Illuminate\Support\Facades\Http;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 
 class AuthController extends Controller
 {
@@ -33,6 +35,54 @@ class AuthController extends Controller
             'user_name' => $data['user_name'],
             'user_password' => bcrypt($data['user_password'])
         ]);
+
+        $client = Client::where('password_client', 1)->first();
+        $tokenRoute = route('passport.token');
+
+        $response = Http::asForm()->post($tokenRoute, [
+            'grant_type' => 'password',
+            'client_id' => $client->id,
+            'client_secret' => $client->secret,
+            'username' => $data['email'],
+            'password' => $data['user_password'],
+            'scope' => '*'
+        ]);
+
+        if ($response->getStatusCode() == 200) {
+            return json_decode((string) $response->getBody(), true);
+        } else {
+            return response()->json([
+                'code' => $response->getStatusCode(),
+                'message' => 'Http request error'
+            ]);
+        }
+    }
+
+    /* 로그인 */
+    public function login(Request $request) {
+        // 유효성 체크
+        $valid = validator($request->only('email', 'user_password'), [
+            'email' => 'required|string|email|max:100',
+            'user_password' => 'required|string|min:6|max:255'
+        ]);
+        if ($valid->fails()) {
+            return response()->json([
+                'error' => $valid->errors()->all()
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = request()->only('email', 'user_password');
+
+        $credential = [
+            'email' => $data['email'],
+            'password' => $data['user_password'],
+        ];
+
+        if (!Auth::attempt($credential)) {
+            return response()->json([
+                'message' => '유효하지 않은 사용자 정보 입니다.'
+            ], Response::HTTP_UNAUTHORIZED);
+        }
 
         $client = Client::where('password_client', 1)->first();
         $tokenRoute = route('passport.token');

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,4 +17,5 @@ use App\Http\Controllers\API\AuthController;
 
 Route::prefix('/user')->group(function() {
     Route::post('register', [AuthController::class, 'register'])->name('user.register');
+    Route::post('login', [AuthController::class, 'login'])->name('user.login');
 });


### PR DESCRIPTION
## 배경
- 인증 `API` 를 추가하여 로그인 기능을 구축해야 합니다.

## 작업내용
- `AuthController` 에 로그인 함수를 추가하고, 인증시도 후 토큰이 발급되도록 작업하였습니다.
-  `API Route` 에 `login` 을 추가하였습니다.

## 테스트방법
- 현재는 머지 후 AWS 에 배포되어야 만 확인할 수 있는 환경입니다. 배포 관련된 부분은 별도로 논의하면 좋겠네요!

## 리뷰노트
- Repository 에 머지되면 AWS 에서 pull 받고 문제없으면 넛지 드릴께요!

## 스크린샷
<img width="1234" alt="스크린샷 2023-12-29 오후 5 51 28" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/84cd4017-2a82-4d8f-acef-6e4caa261415">

