### PR TITLE
회원가입 및 로그인시 사용자ID 를 사용하도록 개선합니다.

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -17,7 +17,8 @@ class AuthController extends Controller
     public function register(Request $request)
     {
         // 유효성 체크
-        $valid = validator($request->only('email', 'user_name', 'user_password'), [
+        $valid = validator($request->only('user_id', 'email', 'user_name', 'user_password'), [
+            'user_id' => 'required|string|max:50|unique:mm_users',
             'email' => 'required|string|email|max:100|unique:mm_users',
             'user_name' => 'required|string|max:50',
             'user_password' => 'required|string|min:6|max:255'
@@ -28,9 +29,10 @@ class AuthController extends Controller
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $data = request()->only('email', 'user_name', 'user_password');
+        $data = request()->only('user_id', 'email', 'user_name', 'user_password');
 
         $user = User::create([
+            'user_id' => $data['user_id'],
             'email' => $data['email'],
             'user_name' => $data['user_name'],
             'user_password' => bcrypt($data['user_password'])
@@ -43,7 +45,7 @@ class AuthController extends Controller
             'grant_type' => 'password',
             'client_id' => $client->id,
             'client_secret' => $client->secret,
-            'username' => $data['email'],
+            'username' => $data['user_id'],
             'password' => $data['user_password'],
             'scope' => '*'
         ]);

--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -63,8 +63,8 @@ class AuthController extends Controller
     /* 로그인 */
     public function login(Request $request) {
         // 유효성 체크
-        $valid = validator($request->only('email', 'user_password'), [
-            'email' => 'required|string|email|max:100',
+        $valid = validator($request->only('user_id', 'user_password'), [
+            'user_id' => 'required|string|max:50',
             'user_password' => 'required|string|min:6|max:255'
         ]);
         if ($valid->fails()) {
@@ -73,10 +73,10 @@ class AuthController extends Controller
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $data = request()->only('email', 'user_password');
+        $data = request()->only('user_id', 'user_password');
 
         $credential = [
-            'email' => $data['email'],
+            'user_id' => $data['user_id'],
             'password' => $data['user_password'],
         ];
 
@@ -93,7 +93,7 @@ class AuthController extends Controller
             'grant_type' => 'password',
             'client_id' => $client->id,
             'client_secret' => $client->secret,
-            'username' => $data['email'],
+            'username' => $data['user_id'],
             'password' => $data['user_password'],
             'scope' => '*'
         ]);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
+        'user_id',
         'user_name',
         'email',
         'user_password',
@@ -52,5 +53,16 @@ class User extends Authenticatable
     public function getAuthPassword(): string
     {
         return $this->user_password;
+    }
+
+    /**
+     * Find the user instance for the given username.
+     *
+     * @param  string  $userid
+     * @return \App\Models\User
+     */
+    public function findForPassport($userid)
+    {
+        return $this->where('user_id', $userid)->first();
     }
 }

--- a/database/migrations/2023_12_15_165339_create_mm_users_table.php
+++ b/database/migrations/2023_12_15_165339_create_mm_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->engine = 'InnoDB';
             $table->charset = 'utf8mb4';
             $table->bigIncrements('id');
+            $table->string('user_id', 50)->unique()->comment('유저아이디');
             $table->string('email', 100)->unique()->default('')->comment('이메일');
             $table->string('user_name', 50)->default('')->comment('회원 이름');
             $table->string('user_password', 255)->default('')->comment('비밀번호');


### PR DESCRIPTION
## 배경
- 이메일을 키로 사용할 경우 회원정보를 찾을 때 사용자만 존재하고, 이름은 중복될 가능성이 높기 때문에 사용자ID 컬럼을 추가하고 이메일은 사용자 정보로만 사용하고자 합니다. 
- 이 PR 에서는 mm_users 테이블에 user_id 컬럼을 추가하고 관련 로직을 모두 수정합니다.

## 작업내용
- `mm_users` 테이블에 `user_id` 컬럼을 추가하였습니다.
- `AuthController` 에 회원가입 및 로그인 비지니스 로직에 user_id 를 추가하여 개선하였습니다.

## 테스트방법
- 머지된 후 회원가입 / 로그인 API 가 정상 수행되어야 합니다.

## 리뷰노트
- 데이터는 롤백할 예정입니다. 기존 가입된 정보는 모두 지워집니다!
- 머지된 후 아래와 같은 과정을 수행해야 합니다.
```
DB 테이블 생성 :  php artisan migrate:reset
인증키 생성 php artisan passport:install
```


