### PR TITLE
아이디 찾기 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -107,4 +107,36 @@ class AuthController extends Controller
             ]);
         }
     }
+
+    /* 아이디 찾기 */
+    public function findId(Request $request) {
+        // 유효성 체크
+        $valid = validator($request->only('email', 'user_name'), [
+            'email' => 'required|string|email|max:100',
+            'user_name' => 'required|string|max:50'
+        ]);
+        if ($valid->fails()) {
+            return response()->json([
+                'error' => $valid->errors()->all()
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = request()->only('email', 'user_name');
+
+        $user = User::where('email', $data['email'])
+                    ->where('user_name', $data['user_name'])
+                    ->first();
+
+        if ($user == null) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '가입된 사용자가 아닙니다.'
+            ]);
+        } else {
+            return response()->json([
+                'result' => 'sucess',
+                'user_id' => $user['user_id']
+            ]);
+        }
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,4 +18,5 @@ use App\Http\Controllers\API\AuthController;
 Route::prefix('/user')->group(function() {
     Route::post('register', [AuthController::class, 'register'])->name('user.register');
     Route::post('login', [AuthController::class, 'login'])->name('user.login');
+    Route::post('findId', [AuthController::class, 'findId'])->name('user.findId');
 });


### PR DESCRIPTION
## 배경
- 회원이 아이디를 잊어버린 경우 필요한 정보를 입력받아 회원 아이디를 알려줘야 합니다.
- 이번 PR 에서는 아이디 찾기 API 기능을 추가해 봅니다.

## 작업내용
- `AuthController` 에 아이디 찾기 함수를 추가하였습니다.
-  `API Route` 에 `findId` 을 추가하였습니다.

## 테스트방법
- 현재는 머지 후 AWS 에 배포되어야 만 확인할 수 있는 환경입니다.

## 리뷰노트
- Repository 에 머지되면 AWS 에서 pull 받고 문제없으면 넛지 드릴께요!

## 스크린샷
<img width="673" alt="스크린샷 2024-01-07 오후 5 08 40" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/60ccdf08-714c-48e0-ad37-59562246d4fa">
