### PR TITLE
비밀번호 재설정 도메인을 `env` 변수를 사용하여 가져오기 위해 `HTTPS` 프로토콜을 제거합니다.

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -35,7 +35,7 @@ class AuthServiceProvider extends ServiceProvider
 
         // 비밀번호 재설정 URL 변경
         ResetPassword::createUrlUsing(function (User $user, string $token) {
-            return 'http://'.env('APP_URL').'/reset-password/'.$token;
+            return env('APP_URL').'/reset-password/'.$token;
         });
     }
 }


### PR DESCRIPTION
## 배경
- #8 PR 에서 비밀번호 변경요청시 메일내용에 비밀번호 변경 화면으로 이동할 수 있는 링크 정보를 `.env` 를 통해 불러오도록 수정했는데, `.env` 에 `HTTPS` 프로토콜이 이미 명시되어 있어 삭제하는 작업을 진행해야 합니다.


## 작업내용
- `AuthServiceProvider` 에서 비밀번호 재설정 `URL` 을 변경하였습니다.


## 테스트 방법
<img width="1245" alt="스크린샷 2024-02-27 오후 5 39 32" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/6ff59675-e18d-4872-a4b6-0012275beb23">
