### PR TITLE
로그인, 회원가입시 토큰을 못가져 오는 문제를 해소합니다.

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -40,7 +40,7 @@ class AuthController extends Controller
         ]);
 
         $client = Client::where('password_client', 1)->first();
-        $tokenRoute = route('passport.token');
+        $tokenRoute = env('APP_URL').route('passport.token', absolute: false);
 
         $response = Http::asForm()->post($tokenRoute, [
             'grant_type' => 'password',
@@ -88,7 +88,7 @@ class AuthController extends Controller
         }
 
         $client = Client::where('password_client', 1)->first();
-        $tokenRoute = route('passport.token');
+        $tokenRoute = env('APP_URL').route('passport.token', absolute: false);
 
         $response = Http::asForm()->post($tokenRoute, [
             'grant_type' => 'password',


### PR DESCRIPTION
## 배경
- `Secure 도메인 (https)` 이 적용되면서 회원가입, 로그인시 토큰을 못가져 오는 문제가 생겼습니다. (error 404) 
- 원인을 파악해보니 `route()` 함수에서는 `Non secure 도메인 (http)` 를 리턴하여 생긴 문제였습니다.
- 이 문제를 해소하기 위해 도메인을 정보를 `env` 에서 가져오도록 개선해 봅니다.

## 작업내용
- 커곧내

## 테스트방법
- 로그인, 회원가입시 정상적으로 수행되어야 합니다. 
- 회원가입

<img width="1234" alt="스크린샷 2024-03-01 오후 6 31 08" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/492eaf2b-1fa1-4796-9a98-1e9b7ff8e3aa">

- 로그인

<img width="1228" alt="스크린샷 2024-03-01 오후 6 31 45" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/f457f7bf-4f84-43db-bce3-842cf22eb16e">

