### PR TITLE
비밀번호를 변경할 수 있습니다.

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -20,4 +20,5 @@ Route::prefix('/user')->group(function() {
     Route::post('login', [AuthController::class, 'login'])->name('user.login');
     Route::post('findId', [AuthController::class, 'findId'])->name('user.findId');
     Route::post('forgot_password', [AuthController::class, 'forgotPassword'])->name('user.forgetPassword');
+    Route::post('reset_password', [AuthController::class, 'resetPassword'])->name('user.resetPassword');
 });


### PR DESCRIPTION
## 배경
- 이메일로 전송된 비밀번호 재설정 링크를 통해 비밀번호를 재설정 할 수 있어야 합니다.

## 작업내용
- `Route` 에 비밀번호 재설정 `Endpoint` 를 추가하였습니다.
- `AuthController` 에서 비밀번호 재설정 로직을 추가하였습니다.

## 테스트방법
<img width="889" alt="스크린샷 2024-03-02 오전 12 14 11" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/10341cd0-0bea-4d04-92df-92f6ec9182c4">

## 리뷰노트
- 비밀번호 재설정 기능의 마지막 PR 입니다.
- `forgot_password` API 를 통해 비밀번호 재설정 링크를 보내는데 그 안에 api.foot-print.co.kr 도메인을 바라보도록 구현되어 있습니다. 추후 FE 개발이 완료되면 해당 비밀번호 재설정 페이지 링크로 수정되어야 합니다. 
