### PR TITLE
기념관을 생성하는 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Attachment;
+use App\Models\Memorial;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Input;
+
+class MemorialController extends Controller
+{
+    private $S3_PATH_PROFILE;
+    private $S3_PATH_BGM;
+
+    public function __construct() {
+        $this->S3_PATH_PROFILE = "/memorial/profile/";
+        $this->S3_PATH_BGM = "/memorial/bgm/";
+    }
+
+    public function register(Request $request) {
+        // 유효성 체크
+        $memorial = Memorial::where('user_id', Auth::user()->user_id)->first();
+        if (!is_null($memorial)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '이미 생성된 기념관이 존재합니다.'
+            ]);
+        }
+
+        $valid = validator($request->only('user_name', 'birth_start', 'birth_end', 'profile'), [
+            'user_name' => 'required|string|max:50',
+            'birth_start' => 'required|sometimes|date_format:Y-m-d',
+            'birth_end' => 'sometimes|date_format:Y-m-d',
+            'profile' => 'required'
+        ]);
+        if ($valid->fails()) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => $valid->errors()->all()
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = request()->only('user_name', 'birth_start', 'birth_end', 'career', 'profile', 'bgm');
+
+        try {
+            DB::beginTransaction();
+
+            $id = Auth::user()->id;
+            $userId = Auth::user()->user_id;
+
+            $memorial = new Memorial();
+            $memorial->user_id = $userId;
+            $memorial->name = $data['user_name'];
+            $memorial->birth_start = $data['birth_start'];
+            $memorial->birth_end = $data['birth_end'];
+            $memorial->career_contents = $data['career'];
+            $memorial->save();
+
+            // 프로필 이미지 업로드
+            $profile_url = $request->file('profile');
+            $file = $request->file('profile')->getClientOriginalName();
+            $extension = pathinfo($file, PATHINFO_EXTENSION);
+            $lowerExtentsion = strtolower($extension);
+            $fileName = $memorial->id."_profile.".$lowerExtentsion;
+            $profilePathFileName = $this->S3_PATH_PROFILE.$fileName;
+
+            $exists = Storage::disk('s3')->exists($profilePathFileName);
+            if ($exists) {
+                Storage::disk('s3')->delete($profilePathFileName);
+            }
+            Storage::disk('s3')->put($profilePathFileName, file_get_contents($profile_url));
+
+            $profileAttachment = new Attachment();
+            $profileAttachment->file_path = $this->S3_PATH_PROFILE;
+            $profileAttachment->file_name = $fileName;
+            $profileAttachment->save();
+
+            $memorial->profile_attachment_id = $profileAttachment->id;
+            $memorial->save();
+
+            // BGM 업로드
+            $bgm_url = $request->file('bgm');
+            if ($bgm_url) {
+                $file = $request->file('bgm')->getClientOriginalName();
+                $extension = pathinfo($file, PATHINFO_EXTENSION);
+                $lowerExtentsion = strtolower($extension);
+                $fileName = $memorial->id."_bgm.".$lowerExtentsion;
+                $bgmPathFileName = $this->S3_PATH_BGM.$fileName;
+
+                $exists = Storage::disk('s3')->exists($bgmPathFileName);
+                if ($exists) {
+                    Storage::disk('s3')->delete($bgmPathFileName);
+                }
+                Storage::disk('s3')->put($bgmPathFileName, file_get_contents($bgm_url));
+
+                $bgmAttachment = new Attachment();
+                $bgmAttachment->file_path = $this->S3_PATH_PROFILE;
+                $bgmAttachment->file_name = $fileName;
+                $bgmAttachment->save();
+
+                $memorial->bgm_attachment_id = $bgmAttachment->id;
+                $memorial->save();
+            }
+
+            DB::commit();
+
+            return response()->json([
+                'result' => 'success',
+                'message' => '기념관 생성에 성공하였습니다.'
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 생성에 실패하였습니다. ['.$e->getMessage().']'
+            ]);
+        }
+    }
+}

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Attachment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'mm_attachments';
+
+    public $timestamps = true;
+}

--- a/app/Models/Memorial.php
+++ b/app/Models/Memorial.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Memorial extends Model
+{
+    use HasFactory;
+
+    protected $table = 'mm_memorials';
+
+    public $timestamps = true;
+}

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,15 @@
     "license": "MIT",
     "require": {
         "php": "^8.0.2",
+        "aws/aws-sdk-php": "^3.303",
         "aws/aws-sdk-php-laravel": "^3.8",
         "doctrine/dbal": "^3.7",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",
         "laravel/passport": "^11.10",
         "laravel/sanctum": "^3.0",
-        "laravel/tinker": "^2.7"
+        "laravel/tinker": "^2.7",
+        "league/flysystem-aws-s3-v3": "^3.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0349fe6f370f37a1117ca4a6869ff3ec",
+    "content-hash": "6442cf7f41552e4aa0b69d4d5618e6ef",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.298.7",
+            "version": "3.303.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b4d98bfc70df146774bf9b04f5ac5b39955fbad2"
+                "reference": "9ae5429f7699701cb158780cd287d1549f45ad32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b4d98bfc70df146774bf9b04f5ac5b39955fbad2",
-                "reference": "b4d98bfc70df146774bf9b04f5ac5b39955fbad2",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9ae5429f7699701cb158780cd287d1549f45ad32",
+                "reference": "9ae5429f7699701cb158780cd287d1549f45ad32",
                 "shasum": ""
             },
             "require": {
@@ -151,9 +151,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.298.7"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.303.4"
             },
-            "time": "2024-02-09T19:07:04+00:00"
+            "time": "2024-04-05T18:04:15+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -2684,6 +2684,71 @@
                 }
             ],
             "time": "2023-12-04T10:16:17+00:00"
+        },
+        {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "885d0a758c71ae3cd6c503544573a1fdb8dc754f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/885d0a758c71ae3cd6c503544573a1fdb8dc754f",
+                "reference": "885d0a758c71ae3cd6c503544573a1fdb8dc754f",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.295.10",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-24T21:11:18+00:00"
         },
         {
             "name": "league/flysystem-local",

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -52,7 +52,6 @@ return [
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
-            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,
         ],
 

--- a/database/migrations/2024_03_01_154118_create_mm_memorials_table.php
+++ b/database/migrations/2024_03_01_154118_create_mm_memorials_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mm_memorials', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->bigIncrements('id')->unique();
+            $table->string('user_id', 50)->unique()->comment('유저아이디')->unique();
+            $table->string('name', 50)->comment('기념인 이름');
+            $table->date('birth_start')->nullable()->comment('태어난 일자');
+            $table->date('birth_end')->nullable()->comment('마감한 일자');
+            $table->text('career_contents')->nullable()->comment('생애');
+            $table->unsignedInteger('profile_attachment_id')->nullable()->comment('프로필 사진 첨부 파일 고유키');
+            $table->unsignedInteger('bgm_attachment_id')->nullable()->comment('배경음악 첨부 파일 고유키');
+            $table->unsignedTinyInteger('is_open')->default(0)->comment('오픈 여부(0:false, 1:true)');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mm_memorials');
+    }
+};

--- a/database/migrations/2024_03_02_163116_create_mm_attachments_table.php
+++ b/database/migrations/2024_03_02_163116_create_mm_attachments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mm_attachments', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->bigIncrements('id')->unique();
+            $table->string('file_path', 255)->default('')->comment('파일 경로');
+            $table->string('file_name', 255)->default('')->comment('파일명');
+            $table->unsignedTinyInteger('is_delete')->default(0)->comment('삭제 여부(0:false, 1:true)');
+            $table->timestamp('deleted_at')->nullable()->comment('삭제 시간');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mm_attachments');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\MemorialController;
 
 /*
 |--------------------------------------------------------------------------
@@ -21,4 +22,8 @@ Route::prefix('/user')->group(function() {
     Route::post('findId', [AuthController::class, 'findId'])->name('user.findId');
     Route::post('forgot_password', [AuthController::class, 'forgotPassword'])->name('user.forgetPassword');
     Route::post('reset_password', [AuthController::class, 'resetPassword'])->name('user.resetPassword');
+});
+
+Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(function() {
+    Route::post('/register', [MemorialController::class, 'register'])->name('register');
 });


### PR DESCRIPTION
## 배경
- 기념관을 생성할 수 있는 API 가 필요합니다.

## 작업내용
- 필요한 패키지를 설치하였습니다. 
- `memorial`,  `attachment` 테이블을 생성을 위한 마이그레이션 파일을 추가하고, 모델을 생성하였습니다.
- `S3` 업로드를 위해 filesystem 설정값에 불필요한 키를 제거하였습니다.
- `MemorialController` 를 생성하고, 기념관 생성 비지니스 로직을 작성하였습니다.
- 기념관 생성 `Route` 를 추가하였습니다.

## 테스트 방법
- access token 이 필요한 API 입니다.
- Header 
<img width="860" alt="스크린샷 2024-04-07 오후 11 07 48" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/3bae1c16-bca5-4cf0-aca5-eb0aa2d435b2">

- Body
<img width="953" alt="스크린샷 2024-04-07 오후 11 07 40" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/98901c07-ff08-4c87-8cb5-afac593eb648">

## 리뷰노트
- 운영 환경에서 패키지 설치가 필요합니다.
```
composer require aws/aws-sdk-php
composer require league/flysystem-aws-s3-v3 "^3.0"
```
- 마이그레이션을 수행해야 합니다.
```
php artisan migrate
```
- `.env` 에서 `S3` 환경 설정을 확인해야 합니다.
- 이미지나 배경음악을 업로드 후 `S3` 버킷의 외부 URL 은 `https://foot-print-resources.s3.ap-northeast-2.amazonaws.com/memorial/bgm/57_bgm.mp3` 형태로 저장됩니다. 
```
profile 이미지 : memorial/profile
bgm : memorial/bgm
```
- 현재는 사용자 1명단 1개의 기념관 생성만 가능하도록 되어 있습니다.