### PR TITLE
기념관 생애 입력시 파일을 업로드 할 수 있습니다.

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -26,4 +26,5 @@ Route::prefix('/user')->group(function() {
 
 Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(function() {
     Route::post('/register', [MemorialController::class, 'register'])->name('register');
+    Route::post('/upload', [MemorialController::class, 'upload'])->name('upload');
 });


### PR DESCRIPTION
## 배경
- 준희님 요청으로 생애 HTML Editor 를 통해 등록된 파일을 S3 에 업로드 할 수 있는 기능이 필요하다고 전달받아 작업합니다.

## 작업내용
- MemoriaController 에 생애 HTML Editor 을 통해 파일 업로드 로직을 구현하였습니다.
- 필요한 Route 도 추가하였습니다.

## 테스트 방법
<img width="1021" alt="스크린샷 2024-04-08 오전 12 31 13" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/fb275d9d-6a30-4dcd-a9d8-b696ee792575">

## 리뷰노트
- #12 커밋이 포함되어 있습니다.
- 인증된 사용자만 사용할 수 있습니다.
