### PR TITLE
기념관 상세보기 API 를 구현합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -267,4 +267,29 @@ class MemorialController extends Controller
             ]);
         }
     }
+
+    public function detail(Request $request, $id) {
+        if (is_null($id)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 ID가 없습니다.'
+            ]);
+        }
+
+        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm'])
+            ->select('id', 'birth_start', 'birth_end', 'career_contents', 'is_open', 'profile_attachment_id', 'bgm_attachment_id', 'created_at', 'updated_at')
+            ->where('id', $id)->first();
+
+        if (is_null($memorial)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 정보가 없습니다.'
+            ]);
+        }
+        return response()->json([
+            'result' => 'success',
+            'message' => '기념관 조회가 성공하였습니다.',
+            'data' => $memorial
+        ]);
+    }
 }

--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -116,7 +116,10 @@ class MemorialController extends Controller
 
             return response()->json([
                 'result' => 'success',
-                'message' => '기념관 생성에 성공하였습니다.'
+                'message' => '기념관 생성에 성공하였습니다.',
+                'data' => [
+                    'id' => $memorial->id
+                ]
             ]);
         } catch (Exception $e) {
             DB::rollBack();

--- a/app/Models/Memorial.php
+++ b/app/Models/Memorial.php
@@ -12,4 +12,12 @@ class Memorial extends Model
     protected $table = 'mm_memorials';
 
     public $timestamps = true;
+
+    public function attachmentProfileImage() {
+        return $this->hasOne(Attachment::class, 'id', 'profile_attachment_id')->where('is_delete', 0);
+    }
+
+    public function attachmentBgm() {
+        return $this->hasOne(Attachment::class, 'id', 'bgm_attachment_id')->where('is_delete', 0);
+    }
 }

--- a/database/migrations/2024_04_10_104318_change_is_open_in_mm_memorials_table.php
+++ b/database/migrations/2024_04_10_104318_change_is_open_in_mm_memorials_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mm_memorials', function (Blueprint $table) {
+            $table->string('is_open')->default(1)->comment('오픈 여부(0:false, 1:true)')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mm_memorials', function (Blueprint $table) {
+            $table->string('is_open')->default(0)->comment('오픈 여부(0:false, 1:true)')->change();
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,4 +28,8 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
     Route::post('/register', [MemorialController::class, 'register'])->name('register');
     Route::post('/upload', [MemorialController::class, 'upload'])->name('upload');
     Route::post('{id}/edit', [MemorialController::class, 'edit'])->name('edit');
+
+    Route::withoutMiddleware('auth:api')->group(function() {
+        Route::get('{id}/detail', [MemorialController::class, 'detail'])->name('detail');
+    });
 });


### PR DESCRIPTION
## 배경
- 기념관 상세보기를 위한 API 가 필요합니다.
- 스토리, 방문자 코멘트 정보는 포함하지 않습니다.

## 작업내용
- `MemorialController`  에서 기념관 상세보기 로직을 구현하였습니다.
- `Memorial` 모델에 프로필 사진, 배경음악 테이블과 연관관계를 정의하였습니다.
- 기념관 상세보기 `Route` 를 추가하였습니다.
- 잠수함 패치로 `mm_memorials` 테이블의 `is_open` 컬럼 기본값을 0에서 1로 수정하였습니다.
- 잠수함 패치로 기념관 생성 API 결과값으로 ID 가 전달되도록 수정하였습니다.

## 테스트방법
<img width="1266" alt="스크린샷 2024-04-10 오후 7 56 42" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/2ce7f9cf-f0cb-4327-a2c5-1a6c814f624d">

## 리뷰노트
- 회원, 비회원 상관없이 조회할 수 있는 API 입니다.