### PR TITLE
기념관 상세보기 API 결과값으로 `Story` 와 `VisitComment` 가 리턴하도록 수정합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -279,7 +279,7 @@ class MemorialController extends Controller
             ]);
         }
 
-        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm'])
+        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm', 'story', 'visitComment'])
             ->select('id', 'birth_start', 'birth_end', 'career_contents', 'is_open', 'profile_attachment_id', 'bgm_attachment_id', 'created_at', 'updated_at')
             ->where('id', $id)->first();
 

--- a/app/Models/Memorial.php
+++ b/app/Models/Memorial.php
@@ -20,4 +20,12 @@ class Memorial extends Model
     public function attachmentBgm() {
         return $this->hasOne(Attachment::class, 'id', 'bgm_attachment_id')->where('is_delete', 0);
     }
+
+    public function story() {
+        return $this->hasMany(Story::class, 'id', 'memorial_id');
+    }
+
+    public function visitComment() {
+        return $this->hasMany(VisitorComment::class, 'id', 'memorial_id');
+    }
 }

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Story extends Model
+{
+    use HasFactory;
+    protected $table = "mm_stories";
+    public $timestamps = true;
+}

--- a/app/Models/VisitorComment.php
+++ b/app/Models/VisitorComment.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class VisitorComment extends Model
+{
+    use HasFactory;
+
+    protected $table = "mm_visitor_comments";
+    public $timestamps = true;
+}

--- a/database/migrations/2024_03_02_164028_create_mm_visitor_comments_table.php
+++ b/database/migrations/2024_03_02_164028_create_mm_visitor_comments_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mm_visitor_comments', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->bigIncrements('id')->unique();
+            $table->unsignedBigInteger('user_id')->default(0)->comment('회원 고유키');
+            $table->unsignedBigInteger('memorial_id')->default(0)->comment('기념관 고유키');
+            $table->text('message')->nullable()->comment('메세지');
+            $table->unsignedTinyInteger('is_visible')->default(1)->comment('노출 여부(0:false, 1:true)');
+            $table->timestamps();
+            $table->foreign('user_id')->references('id')->on('mm_users')->cascadeOnDelete();
+            $table->foreign('memorial_id')->references('id')->on('mm_memorials')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mm_visitor_comments');
+    }
+};

--- a/database/migrations/2024_03_02_165029_create_mm_stories_table.php
+++ b/database/migrations/2024_03_02_165029_create_mm_stories_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mm_stories', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->bigIncrements('id')->unique();
+            $table->unsignedBigInteger('user_id')->default(0)->comment('회원 고유키');
+            $table->unsignedBigInteger('memorial_id')->default(0)->comment('기념관 고유키');
+            $table->text('message')->nullable()->comment('메세지');
+            $table->unsignedBigInteger('attachment_id')->nullable()->comment('첨부 파일 고유키');
+            $table->unsignedTinyInteger('is_visible')->default(1)->comment('노출 여부(0:false, 1:true)');
+            $table->timestamps();
+            $table->foreign('user_id')->references('id')->on('mm_users')->cascadeOnDelete();
+            $table->foreign('memorial_id')->references('id')->on('mm_memorials')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mm_stories');
+    }
+};


### PR DESCRIPTION
## 배경
- 기념관 상세보기 API 결과값으로 스토리, 방문자 코멘트 목록이 전달되어야 합니다.

## 작업내용
- 스토리, 방문자 코멘트 테이블 생성을 위한 마이그레이션 파일을 추가하고, 모델을 생성한 후, `Memorial` 모델과 연관관계를 설정하였습니다.
- `MemorialController` 의 기념관 상세보기 로직에서 스토리, 방문자 코멘트 정보가 전달되도록 수정하였습니다.

## 테스트방법
<img width="1493" alt="스크린샷 2024-04-10 오후 8 42 19" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/9b50449e-d821-4422-878f-2c3446488784">

## 리뷰노트
- #15 커밋이 포함되어 있습니다!