### PR TITLE
방문자 코멘트 등록 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/CommentController.php
+++ b/app/Http/Controllers/API/CommentController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\VisitorComment;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class CommentController extends Controller
+{
+    public function __construct() {
+
+    }
+
+    public function register(Request $request, $memorialId) {
+        // 유효성 체크
+        if (is_null($memorialId)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 ID가 없습니다.'
+            ]);
+        }
+
+        $valid = validator($request->only('message'), [
+            'message' => 'required'
+        ]);
+        if ($valid->fails()) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => $valid->errors()->all()
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = request()->only('message');
+
+        try {
+            DB::beginTransaction();
+
+            $userId = Auth::user()->id;
+
+            $comment = new VisitorComment();
+            $comment->user_id = $userId;
+            $comment->memorial_id = $memorialId;
+            $comment->message = $data['message'];
+            $comment->save();
+
+            DB::commit();
+        } catch (Exception $e) {
+            DB::rollBack();
+
+            return response()->json([
+                'result' => 'fail',
+                'message' => '코멘트 생성에 실패하였습니다. ['.$e->getMessage().']'
+            ]);
+        }
+
+        // 모든 코멘트 목록을 리턴합니다.
+        $commentList = VisitorComment::join('mm_users as user', 'mm_visitor_comments.user_id', 'user.id')
+            ->select('mm_visitor_comments.id', 'mm_visitor_comments.user_id', 'user.user_name', 'mm_visitor_comments.memorial_id', 'mm_visitor_comments.message', 'mm_visitor_comments.is_visible', 'mm_visitor_comments.created_at', 'mm_visitor_comments.updated_at')
+            ->where('mm_visitor_comments.memorial_id', $memorialId)
+            ->where('mm_visitor_comments.is_visible', 1)->orderBy('mm_visitor_comments.created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'result' => 'success',
+            'message' => '코멘트 생성에 성공하였습니다.',
+            'data' => $commentList
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\CommentController;
 use App\Http\Controllers\API\MemorialController;
 
 /*
@@ -32,4 +33,6 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
     Route::withoutMiddleware('auth:api')->group(function() {
         Route::get('{id}/detail', [MemorialController::class, 'detail'])->name('detail');
     });
+
+    Route::post('{id}/comment/register', [CommentController::class, 'register'])->name('comment.register');
 });


### PR DESCRIPTION
## 배경
- 기념관 방문자는 코멘트를 작성할 수 있어야 합니다.

## 작업내용
- 방문자 코멘트 작성 및 목록 비지니스 로직을 처리할 `CommentController` 를 생성하고 작성 로직을 구현하였습니다.
- 코멘트 작성 Route 를 추가하였습니다.

## 테스트방법
<img width="1217" alt="스크린샷 2024-04-11 오전 2 12 09" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/e283444b-8ad8-4309-a080-a257867e6765">

## 리뷰노트
- 코멘트 작성을 위해서는 인증이 필요합니다.