### PR TITLE
방문자 코멘트 목록 조회 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/CommentController.php
+++ b/app/Http/Controllers/API/CommentController.php
@@ -71,4 +71,27 @@ class CommentController extends Controller
             'data' => $commentList
         ]);
     }
+
+    public function list(Request $request, $memorialId) {
+        // 유효성 체크
+        if (is_null($memorialId)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 ID가 없습니다.'
+            ]);
+        }
+
+        // 모든 코멘트 목록을 리턴합니다.
+        $commentList = VisitorComment::join('mm_users as user', 'mm_visitor_comments.user_id', 'user.id')
+            ->select('mm_visitor_comments.id', 'mm_visitor_comments.user_id', 'user.user_name', 'mm_visitor_comments.memorial_id', 'mm_visitor_comments.message', 'mm_visitor_comments.is_visible', 'mm_visitor_comments.created_at', 'mm_visitor_comments.updated_at')
+            ->where('mm_visitor_comments.memorial_id', $memorialId)
+            ->where('mm_visitor_comments.is_visible', 1)->orderBy('mm_visitor_comments.created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'result' => 'success',
+            'message' => '코멘트 조회가 성공하였습니다.',
+            'data' => $commentList
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,7 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
 
     Route::withoutMiddleware('auth:api')->group(function() {
         Route::get('{id}/detail', [MemorialController::class, 'detail'])->name('detail');
+        Route::get('{id}/comments', [CommentController::class, 'list'])->name('comment.list');
     });
 
     Route::post('{id}/comment/register', [CommentController::class, 'register'])->name('comment.register');


### PR DESCRIPTION
## 배경
- 기념관 방문자는 코멘트 목록을 조회할 수 있어야 합니다.

## 작업내용
- `CommentController` 방문자 코멘트 목록을 조회 로직을 구현하였습니다.
- 코멘트 목록 조회 `Route` 를 추가하였습니다.

## 테스트방법
<img width="1246" alt="스크린샷 2024-04-13 오후 1 54 27" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/eaaf0adf-84ed-44cb-99f3-aa64e3ed0efd">
