### PR TITLE
기념관 상세조회시 방문자 코멘트 목록이 표시되도록 수정합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Models\Attachment;
 use App\Models\Memorial;
+use App\Models\VisitorComment;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -279,7 +280,7 @@ class MemorialController extends Controller
             ]);
         }
 
-        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm', 'story', 'visitComment'])
+        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm', 'story', 'visitComments'])
             ->select('id', 'birth_start', 'birth_end', 'career_contents', 'is_open', 'profile_attachment_id', 'bgm_attachment_id', 'created_at', 'updated_at')
             ->where('id', $id)->first();
 

--- a/app/Models/Memorial.php
+++ b/app/Models/Memorial.php
@@ -22,7 +22,7 @@ class Memorial extends Model
     }
 
     public function story() {
-        return $this->hasMany(Story::class, 'id', 'memorial_id');
+        return $this->hasMany(Story::class, 'memorial_id', 'id')->where('is_visible', 1);
     }
 
     public function visitComments() {

--- a/app/Models/Memorial.php
+++ b/app/Models/Memorial.php
@@ -25,7 +25,11 @@ class Memorial extends Model
         return $this->hasMany(Story::class, 'id', 'memorial_id');
     }
 
-    public function visitComment() {
-        return $this->hasMany(VisitorComment::class, 'id', 'memorial_id');
+    public function visitComments() {
+        return $this->hasMany(VisitorComment::class, 'memorial_id', 'id')
+            ->join('mm_users as user', 'mm_visitor_comments.user_id', 'user.id')
+            ->select('mm_visitor_comments.id', 'mm_visitor_comments.user_id', 'user.user_name', 'mm_visitor_comments.memorial_id', 'mm_visitor_comments.message', 'mm_visitor_comments.is_visible', 'mm_visitor_comments.created_at', 'mm_visitor_comments.updated_at')
+            ->where('mm_visitor_comments.is_visible', 1)
+            ->orderBy('mm_visitor_comments.created_at', 'desc');
     }
 }


### PR DESCRIPTION
## 배경
- 기념관 상세 정보 중 방문자 메세지 목록이 표시되지 않는 문제를 해결해야 합니다.
- 또한 방문자 메세지에는 작성자 이름도 추가되어야 합니다.

## 작업내용
- `Memorial` 모델에서 방문자 메세지 연관관계 엘로컨트에 User 모델과 join 하여 사용자 이름이 표시되도록 수정하였습니다.
- 이 과정에서 연관관계 키 설정이 잘못 설정되어 수정하였습니다.
- `MemorialController` 에서 변경된 방문자 메세지 연관관계를 사용하도록 수정하였습니다.

## 테스트방법
<img width="1225" alt="스크린샷 2024-04-13 오후 3 12 02" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/961f43fe-79c6-4991-85f7-64dd1b24fb7e">

## 리뷰노트
- #18 커밋이 포함되어 있습니다.