### PR TITLE
기념관 스토리를 등록하는 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/StoryController.php
+++ b/app/Http/Controllers/API/StoryController.php
@@ -96,8 +96,9 @@ class StoryController extends Controller
         }
 
         // 모든 스토리 목록을 리턴합니다.
-        $storyList = Story::join('mm_users as user', 'mm_stories.user_id', 'user.id')
-            ->select('mm_stories.id', 'mm_stories.user_id', 'user.user_name', 'mm_stories.memorial_id', 'mm_stories.title', 'mm_stories.message', 'mm_stories.is_visible', 'mm_stories.created_at', 'mm_stories.updated_at')
+        $storyList = Story::with('attachment')
+            ->join('mm_users as user', 'mm_stories.user_id', 'user.id')
+            ->select('mm_stories.id', 'mm_stories.user_id', 'user.user_name', 'mm_stories.memorial_id', 'mm_stories.title', 'mm_stories.message', 'mm_stories.attachment_id', 'mm_stories.is_visible', 'mm_stories.created_at', 'mm_stories.updated_at')
             ->where('mm_stories.memorial_id', $memorialId)
             ->where('mm_stories.user_id', $userId)
             ->where('mm_stories.is_visible', 1)->orderBy('mm_stories.created_at', 'desc')

--- a/app/Http/Controllers/API/StoryController.php
+++ b/app/Http/Controllers/API/StoryController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Attachment;
+use App\Models\Memorial;
+use App\Models\Story;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class StoryController extends Controller
+{
+    private $S3_PATH_STORY_ATTACHMENT;
+
+    public function __construct() {
+        $this->S3_PATH_STORY_ATTACHMENT = "/memorial/story/";
+    }
+
+    public function register(Request $request, $memorialId) {
+        // 유효성 체크
+        if (is_null($memorialId)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 ID가 없습니다.'
+            ]);
+        }
+
+        $userId = Auth::user()->id;
+
+        $memorial = Memorial::where('id', $memorialId)->where('user_id', $userId)->first();
+        if (is_null($memorial)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 스토리를 등록할 권한이 없습니다.'
+            ]);
+        }
+
+        $valid = validator($request->only('title', 'message', 'attachment'), [
+            'title' => 'required|string|max:255',
+            'message' => 'required'
+        ]);
+        if ($valid->fails()) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => $valid->errors()->all()
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = request()->only('title', 'message', 'attachment');
+
+        try {
+            DB::beginTransaction();
+
+            $story = new Story();
+            $story->user_id = $userId;
+            $story->memorial_id = $memorialId;
+            $story->title = $data['title'];
+            $story->message = $data['message'];
+            $story->save();
+
+            // 첨부파일 업로드
+            $attachment_url = $request->file('attachment');
+            $file = $request->file('attachment')->getClientOriginalName();
+            $extension = pathinfo($file, PATHINFO_EXTENSION);
+            $lowerExtentsion = strtolower($extension);
+            $fileName = $story->id.".".$lowerExtentsion;
+            $attachmentPathFileName = $this->S3_PATH_STORY_ATTACHMENT.$fileName;
+
+            $exists = Storage::disk('s3')->exists($attachmentPathFileName);
+            if ($exists) {
+                Storage::disk('s3')->delete($attachmentPathFileName);
+            }
+            Storage::disk('s3')->put($attachmentPathFileName, file_get_contents($attachment_url));
+
+            $attachment = new Attachment();
+            $attachment->file_path = $this->S3_PATH_STORY_ATTACHMENT;
+            $attachment->file_name = $fileName;
+            $attachment->save();
+
+            $story->attachment_id = $attachment->id;
+            $story->save();
+
+            DB::commit();
+        } catch (Exception $e) {
+            DB::rollBack();
+
+            return response()->json([
+                'result' => 'fail',
+                'message' => '스토리 생성에 실패하였습니다. ['.$e->getMessage().']'
+            ]);
+        }
+
+        // 모든 스토리 목록을 리턴합니다.
+        $storyList = Story::join('mm_users as user', 'mm_stories.user_id', 'user.id')
+            ->select('mm_stories.id', 'mm_stories.user_id', 'user.user_name', 'mm_stories.memorial_id', 'mm_stories.title', 'mm_stories.message', 'mm_stories.is_visible', 'mm_stories.created_at', 'mm_stories.updated_at')
+            ->where('mm_stories.memorial_id', $memorialId)
+            ->where('mm_stories.user_id', $userId)
+            ->where('mm_stories.is_visible', 1)->orderBy('mm_stories.created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'result' => 'success',
+            'message' => '스토리 생성에 성공하였습니다.',
+            'data' => $storyList
+        ]);
+    }
+}

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -10,4 +10,8 @@ class Story extends Model
     use HasFactory;
     protected $table = "mm_stories";
     public $timestamps = true;
+
+    public function attachment() {
+        return $this->hasOne(Attachment::class, 'id', 'attachment_id')->where('is_delete', 0);
+    }
 }

--- a/database/migrations/2024_04_13_140508_add_title_in_mm_stories_table.php
+++ b/database/migrations/2024_04_13_140508_add_title_in_mm_stories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mm_stories', function (Blueprint $table) {
+            $table->string('title', 255)->comment('제목')->after('memorial_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mm_stories', function (Blueprint $table) {
+            $table->dropColumn('title');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AuthController;
 use App\Http\Controllers\API\CommentController;
 use App\Http\Controllers\API\MemorialController;
+use App\Http\Controllers\API\StoryController;
 
 /*
 |--------------------------------------------------------------------------
@@ -36,4 +37,5 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
     });
 
     Route::post('{id}/comment/register', [CommentController::class, 'register'])->name('comment.register');
+    Route::post('{id}/story/register', [StoryController::class, 'register'])->name('story.register');
 });


### PR DESCRIPTION
## 배경
- 기념관 생성한 유저는 스토리를 등록할 수 있어야 합니다.

## 작업내용
- `mm_stories` 테이블에 누락된 `title` 컬럼을 추가하는 마이그레이션 파일을 생성하였습니다.
- `StoryController` 를 생성하고, 스토리 등록 로직을 구현하였습니다.
- 스토리 등록 `Route` 를 추가하였습니다.
- `Story` 모델과 `Attachment` 모델간의 연관관계를 추가하였습니다.
- `StoryController` 에서 스토리 등록시 첨부파일 정보도 리턴되도록 수정하였습니다.

## 테스트방법
- Body
<img width="1247" alt="스크린샷 2024-04-14 오전 12 42 58" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/101e858f-00d9-4230-a70f-69bf9374d12a">

- Header
<img width="1232" alt="스크린샷 2024-04-14 오전 12 43 07" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/9fdcb949-4a30-4bed-b5ed-867b3980e684">

## 리뷰노트
- #20 커밋이 포함되어 있습니다.
- 운영환경에서 마이그레이션이 필요합니다.
```
php artisan migrate
```