### PR TITLE
기념관 스토리 목록을 조회하는 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/StoryController.php
+++ b/app/Http/Controllers/API/StoryController.php
@@ -110,4 +110,28 @@ class StoryController extends Controller
             'data' => $storyList
         ]);
     }
+
+    public function list(Request $request, $memorialId) {
+        // 유효성 체크
+        if (is_null($memorialId)) {
+            return response()->json([
+                'result' => 'fail',
+                'message' => '기념관 ID가 없습니다.'
+            ]);
+        }
+
+        // 모든 스토리 목록을 리턴합니다.
+        $storyList = Story::with('attachment')
+            ->join('mm_users as user', 'mm_stories.user_id', 'user.id')
+            ->select('mm_stories.id', 'mm_stories.user_id', 'user.user_name', 'mm_stories.memorial_id', 'mm_stories.title', 'mm_stories.message', 'mm_stories.attachment_id', 'mm_stories.is_visible', 'mm_stories.created_at', 'mm_stories.updated_at')
+            ->where('mm_stories.memorial_id', $memorialId)
+            ->where('mm_stories.is_visible', 1)->orderBy('mm_stories.created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'result' => 'success',
+            'message' => '스토리 조회가 성공하였습니다.',
+            'data' => $storyList
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,6 +34,7 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
     Route::withoutMiddleware('auth:api')->group(function() {
         Route::get('{id}/detail', [MemorialController::class, 'detail'])->name('detail');
         Route::get('{id}/comments', [CommentController::class, 'list'])->name('comment.list');
+        Route::get('{id}/stories', [StoryController::class, 'list'])->name('story.list');
     });
 
     Route::post('{id}/comment/register', [CommentController::class, 'register'])->name('comment.register');


### PR DESCRIPTION
## 배경
- 기념관 스토리 목록을 조회할 수 있어야 합니다.

## 작업내용
- `StoryController` 에서 스토리 목록을 리턴하는 로직을 구현하고, `Route` 를 추가하였습니다.

## 테스트방법
<img width="1236" alt="스크린샷 2024-04-14 오전 12 47 57" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/50441dbd-bd01-470b-9663-e5e479988e60">

## 리뷰노트
- #21 커밋이 포함되어 있습니다.
- 모든 사용자가 조회할 수 있는 API 입니다.
