### PR TITLE
인증된 사용자가 기념관 정보를 조회할 수 있는 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -296,4 +296,17 @@ class MemorialController extends Controller
             'data' => $memorial
         ]);
     }
+
+    public function view(Request $request) {
+        $userId = Auth::user()->id;
+
+        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm'])
+            ->where('user_id', $userId)->first();
+
+        return response()->json([
+            'result' => 'success',
+            'message' => '기념관 조회가 성공하였습니다.',
+            'data' => $memorial
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,6 +30,7 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
     Route::post('/register', [MemorialController::class, 'register'])->name('register');
     Route::post('/upload', [MemorialController::class, 'upload'])->name('upload');
     Route::post('{id}/edit', [MemorialController::class, 'edit'])->name('edit');
+    Route::get('/view', [MemorialController::class, 'view'])->name('view');
 
     Route::withoutMiddleware('auth:api')->group(function() {
         Route::get('{id}/detail', [MemorialController::class, 'detail'])->name('detail');


### PR DESCRIPTION
## 배경
- 인증된 사용자가 기념관 수정을 위해 필요한 정보를 받을 수 있는 API 가 필요합니다.

## 작업내용
- `MemorialController` 에 인증된 사용자의 기념관 정보를 리턴하는 로직을 추가하고, `Route` 를 생성하였습니다.

## 테스트방법
<img width="1261" alt="스크린샷 2024-04-14 오전 1 37 31" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/078cc4da-9141-47c7-b32d-8930e8d458f2">

## 리뷰노트
- #21 커밋이 포함되어 있습니다