### PR TITLE
최근 등록된 기념관 4개를 조회하는 API 를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -316,7 +316,7 @@ class MemorialController extends Controller
             ->select('mm_memorials.id', 'mm_memorials.user_id', 'user.user_name', 'mm_memorials.career_contents', 'mm_memorials.profile_attachment_id', 'mm_memorials.bgm_attachment_id')
             ->where('mm_memorials.is_open', 1)
             ->orderBy('mm_memorials.created_at', 'desc')
-            ->limit(3)->get();
+            ->limit(4)->get();
 
         return response()->json([
             'result' => 'success',

--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -309,4 +309,19 @@ class MemorialController extends Controller
             'data' => $memorial
         ]);
     }
+
+    public function index(Request $request) {
+        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm'])
+            ->join('mm_users as user', 'mm_memorials.user_id', 'user.id')
+            ->select('mm_memorials.id', 'mm_memorials.user_id', 'user.user_name', 'mm_memorials.career_contents', 'mm_memorials.profile_attachment_id', 'mm_memorials.bgm_attachment_id')
+            ->where('mm_memorials.is_open', 1)
+            ->orderBy('mm_memorials.created_at', 'desc')
+            ->limit(3)->get();
+
+        return response()->json([
+            'result' => 'success',
+            'message' => '최근 등록된 3개의 기념관 조회가 성공하였습니다.',
+            'data' => $memorial
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,7 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
     Route::get('/view', [MemorialController::class, 'view'])->name('view');
 
     Route::withoutMiddleware('auth:api')->group(function() {
+        Route::get('index', [MemorialController::class, 'index'])->name('index');
         Route::get('{id}/detail', [MemorialController::class, 'detail'])->name('detail');
         Route::get('{id}/comments', [CommentController::class, 'list'])->name('comment.list');
         Route::get('{id}/stories', [StoryController::class, 'list'])->name('story.list');


### PR DESCRIPTION
## 배경
- 메인화면에서 최근 등록된 기념관 4개를 조회하는 API 가 필요합니다.

## 작업내용
- `MemorialController` 에 최근 등록된 4개의 기념관 정보를 조회하는 로직을 추가하고, `Route` 를 생성하였습니다.

## 테스트방법
<img width="1236" alt="스크린샷 2024-04-14 오전 1 52 43" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/0203b4e0-9f24-4c95-85f5-46baed163054">

## 리뷰노트
- #23 커밋이 포함되어 있습니다.
- API 마지막 작업입니다. 혹시 누락되거나 수정이 필요한 부분 있으면 언제든지 알려주세요!