### PR TITLE
기념관 생성, 수정 및 생애 이미지 업로드시 유효성 체크 방식을 개선하고, 버그를 수정합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Validator;
 
 class MemorialController extends Controller
 {
@@ -30,7 +31,7 @@ class MemorialController extends Controller
 
     public function register(Request $request) {
         // 유효성 체크
-        $memorial = Memorial::where('user_id', Auth::user()->user_id)->first();
+        $memorial = Memorial::where('user_id', Auth::user()->id)->first();
         if (!is_null($memorial)) {
             return response()->json([
                 'result' => 'fail',
@@ -69,7 +70,6 @@ class MemorialController extends Controller
             DB::beginTransaction();
 
             $id = Auth::user()->id;
-            $userId = Auth::user()->user_id;
 
             $memorial = new Memorial();
             $memorial->user_id = $id;
@@ -169,7 +169,7 @@ class MemorialController extends Controller
             $extension = pathinfo($file, PATHINFO_EXTENSION);
             $lowerExtentsion = strtolower($extension);
             $randomString = random_int(1, 10000000);
-            $fileName = Auth::user()->user_id."_".$randomString.".".$lowerExtentsion;
+            $fileName = Auth::user()->id."_".$randomString.".".$lowerExtentsion;
             $uploadPathFileName = $this->S3_PATH_CAREER_CONTENT_FILE.$fileName;
             Storage::disk('s3')->put($uploadPathFileName, file_get_contents($upload_file_url));
 

--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -38,16 +38,28 @@ class MemorialController extends Controller
             ]);
         }
 
-        $valid = validator($request->only('user_name', 'birth_start', 'birth_end', 'profile'), [
-            'user_name' => 'required|string|max:50',
+        $validator = Validator::make($request->all(), [
+            'user_name' => 'required|max:50',
             'birth_start' => 'required|sometimes|date_format:Y-m-d',
             'birth_end' => 'sometimes|date_format:Y-m-d',
-            'profile' => 'required'
+            'profile' => 'required|mimes:jpeg,jpg,png|max:1024',
+            'bgm' => 'sometimes|mimes:mp3|max:4096',
+        ], [
+            'user_name.required' => '기념인 이름을 입력해 주세요',
+            'user_name.max' => '기념인 이름은 50자 이내로 입력해 주세요',
+            'birth_start.required' => '기념인 태어난 생년월일을 입력해 주세요',
+            'birth_end.sometimes' => '기념인 돌아간 생년월일을 입력해 주세요',
+            'profile.required' => '기념인 프로필 사진을 선택해 주세요',
+            'profile.mimes' => '기념인 프로필 사진은 jpg/jpeg/png 형식이여야 합니다',
+            'profile.max' => '기념인 프로필 사진은 1Mb 이하여야 합니다',
+            'bgm.mimes' => '기념관 배경 음악은 mp3 형식이여야 합니다',
+            'bgm.max' => '기념관 배경 음악은 4Mb 이하여야 합니다'
         ]);
-        if ($valid->fails()) {
+
+        if ($validator->fails()) {
             return response()->json([
                 'result' => 'fail',
-                'message' => $valid->errors()->all()
+                'message' => $validator->errors()->all()
             ], Response::HTTP_BAD_REQUEST);
         }
 
@@ -133,13 +145,18 @@ class MemorialController extends Controller
     }
 
     public function upload(Request $request) {
-        $valid = validator($request->only('career_contents_file'), [
-            'career_contents_file' => 'required'
+        $validator = Validator::make($request->all(), [
+            'career_contents_file' => 'required|mimes:jpeg,jpg,png|max:1024'
+        ], [
+            'career_contents_file.required' => '이미지를 선택해 주세요',
+            'career_contents_file.mimes' => '이미지는 jpg/jpeg/png 형식이여야 합니다',
+            'career_contents_file.max' => '이미지는 1Mb 이하여야 합니다'
         ]);
-        if ($valid->fails()) {
+
+        if ($validator->fails()) {
             return response()->json([
                 'result' => 'fail',
-                'message' => $valid->errors()->all()
+                'message' => $validator->errors()->all()
             ], Response::HTTP_BAD_REQUEST);
         }
 
@@ -178,6 +195,24 @@ class MemorialController extends Controller
                 'message' => '존재하지 않는 기념관입니다.'
             ]);
         }
+
+        $validator = Validator::make($request->all(), [
+            'user_name' => 'required|max:50',
+            'birth_start' => 'required|sometimes|date_format:Y-m-d',
+            'birth_end' => 'sometimes|date_format:Y-m-d',
+            'profile' => 'required|mimes:jpeg,jpg,png|max:1024',
+            'bgm' => 'sometimes|mimes:mp3|max:4096',
+        ], [
+            'user_name.required' => '기념인 이름을 입력해 주세요',
+            'user_name.max' => '기념인 이름은 50자 이내로 입력해 주세요',
+            'birth_start.required' => '기념인 태어난 생년월일을 입력해 주세요',
+            'birth_end.sometimes' => '기념인 돌아간 생년월일을 입력해 주세요',
+            'profile.required' => '기념인 프로필 사진을 선택해 주세요',
+            'profile.mimes' => '기념인 프로필 사진은 jpg/jpeg/png 형식이여야 합니다',
+            'profile.max' => '기념인 프로필 사진은 1Mb 이하여야 합니다',
+            'bgm.mimes' => '기념관 배경 음악은 mp3 형식이여야 합니다',
+            'bgm.max' => '기념관 배경 음악은 4Mb 이하여야 합니다'
+        ]);
 
         $valid = validator($request->only('user_name', 'birth_start', 'birth_end', 'profile'), [
             'user_name' => 'required|string|max:50',


### PR DESCRIPTION
## 배경
- 지난 위클리에서 정리한 아래 내용을 수정해야합니다.
- 기념관 수정시 배경 이미지는 옵셔널이여야 하고, 이미지 업로드 사이즈는 1M 이하, 배경음악은 4M 이하여야 합니다.

## 작업내용
- `MemorialController` 에서 기념관 등록/수정 및 생애 이미지 업로드시 유효성 체크 로직을 validate 에서 Validator 를 사용하여 사용자에게 보여지는 메세지까지 전달되도록 개선하였습니다.
- 잠수함 패치로 기념관의 사용자 foreignKey 가 user_id 문자열을 사용하고 있던 부분을 모두 user_id 번호를 사용하도록 수정하였습니다.

## 테스트 방법
- 기념관 생성시 이미지는 1M 이하, 음악은 4M 이하만 업로드 가능해야 합니다. (단, 운영환경은 아직 Nginx 설정이 안된 상태입니다)
- 기념관 수정시 음악을 업로드 안해도 수정되어야 합니다.

## 리뷰노트
- 운영환경에서 `client_max_body_size 4M;` 설정이 추가되어야 합니다.