### PR TITLE
스토리 등록시 유효성 검증 실패시 메세지를 세분화하고, 첨부파일을 선택사항으로 수정합니다.

### DIFF
--- a/app/Http/Controllers/API/StoryController.php
+++ b/app/Http/Controllers/API/StoryController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 
 class StoryController extends Controller
 {
@@ -40,14 +41,21 @@ class StoryController extends Controller
             ]);
         }
 
-        $valid = validator($request->only('title', 'message', 'attachment'), [
+        $validator = Validator::make($request->all(), [
             'title' => 'required|string|max:255',
-            'message' => 'required'
+            'message' => 'required',
+            'attachment' => 'sometimes|max:4096'
+        ], [
+            'title.required' => '제목을 입력해 주세요',
+            'title.max' => '제목은 255자 이내로 입력해 주세요',
+            'message.required' => '스토리를 입력해 주세요',
+            'attachment.max' => '첨부파일은 4Mb 이하여야 합니다'
         ]);
-        if ($valid->fails()) {
+
+        if ($validator->fails()) {
             return response()->json([
                 'result' => 'fail',
-                'message' => $valid->errors()->all()
+                'message' => $validator->errors()->all()
             ], Response::HTTP_BAD_REQUEST);
         }
 


### PR DESCRIPTION
## 배경
- 스토리 등록할 때 유효성 검증 실패가 발생하면 어떤 문제인지 정확하게 인지해야 합니다. 
- 또한 스토리 등록할 때 첨부파일은 선택사항으로 변경이 필요합니다.

## 작업내용
- 커곧내

## 테스트 방법
- 스토리 등록시 유효성 체크 실패할 때 자세한 오류 메세지가 표시되어야 합니다.
- 첨부파일이 없어도 등록되어야 합니다.

## 리뷰노트
- #25 커밋이 포함되어 있습니다
- 운영환경에서 `client_max_body_size 4M;` 설정이 추가되어야 합니다.