### PR TITLE
기념관 상세 조회시 작성인 이름도 전달되도록 개선합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -312,8 +312,9 @@ class MemorialController extends Controller
         }
 
         $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm', 'story', 'visitComments'])
-            ->select('id', 'birth_start', 'birth_end', 'career_contents', 'is_open', 'profile_attachment_id', 'bgm_attachment_id', 'created_at', 'updated_at')
-            ->where('id', $id)->first();
+            ->join('mm_users as user', 'mm_memorials.user_id', 'user.id')
+            ->select('mm_memorials.id', 'user.user_name', 'mm_memorials.birth_start', 'mm_memorials.birth_end', 'mm_memorials.career_contents', 'mm_memorials.is_open', 'mm_memorials.profile_attachment_id', 'mm_memorials.bgm_attachment_id', 'mm_memorials.created_at', 'mm_memorials.updated_at')
+            ->where('mm_memorials.id', $id)->first();
 
         if (is_null($memorial)) {
             return response()->json([


### PR DESCRIPTION
## 배경
- 기념관 상세 조회 API 에 작성자 이름을 추가해달라는 요청으로 작업합니다.

## 작업내용
- 커곧내

## 테스트 방법
- `/api/memorial/{기념관ID}/detail` 조회시 user_name  이 전달되어야 합니다.
<img width="592" alt="스크린샷 2024-05-11 오전 1 07 51" src="https://github.com/Genithlabs/memorial-admin-api/assets/360568/7c5383ea-50c9-4c05-a03c-e014724b7671">


## 리뷰노트
- #25 커밋이 포함되어 있습니다.