### PR TITLE
기념관 생성/수정시 birth_end 를 옵셔널로 수정합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -73,7 +73,9 @@ class MemorialController extends Controller
             $memorial->user_id = $id;
             $memorial->name = $data['user_name'];
             $memorial->birth_start = $data['birth_start'];
-            $memorial->birth_end = $data['birth_end'];
+            if (isset($data['birth_end'])) {
+                $memorial->birth_end = $data['birth_end'];
+            }
             $memorial->career_contents = $data['career'];
             $memorial->save();
 
@@ -227,7 +229,7 @@ class MemorialController extends Controller
             $updateColumn = [
                 'name' =>  $data['user_name'],
                 'birth_start' => $data['birth_start'],
-                'birth_end' => $data['birth_end'],
+                'birth_end' => (isset($data['birth_end']) ? $data['birth_end'] : null),
                 'career_contents' => $data['career']
             ];
 

--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -42,14 +42,12 @@ class MemorialController extends Controller
         $validator = Validator::make($request->all(), [
             'user_name' => 'required|max:50',
             'birth_start' => 'required|sometimes|date_format:Y-m-d',
-            'birth_end' => 'sometimes|date_format:Y-m-d',
             'profile' => 'required|mimes:jpeg,jpg,png|max:1024',
             'bgm' => 'sometimes|mimes:mp3,mp4,mpa|max:4096',
         ], [
             'user_name.required' => '기념인 이름을 입력해 주세요',
             'user_name.max' => '기념인 이름은 50자 이내로 입력해 주세요',
             'birth_start.required' => '기념인 태어난 생년월일을 입력해 주세요',
-            'birth_end.sometimes' => '기념인 돌아간 생년월일을 입력해 주세요',
             'profile.required' => '기념인 프로필 사진을 선택해 주세요',
             'profile.mimes' => '기념인 프로필 사진은 jpg/jpeg/png 형식이여야 합니다',
             'profile.max' => '기념인 프로필 사진은 1Mb 이하여야 합니다',
@@ -199,14 +197,12 @@ class MemorialController extends Controller
         $validator = Validator::make($request->all(), [
             'user_name' => 'required|max:50',
             'birth_start' => 'required|sometimes|date_format:Y-m-d',
-            'birth_end' => 'sometimes|date_format:Y-m-d',
             'profile' => 'sometimes|mimes:jpeg,jpg,png|max:1024',
             'bgm' => 'sometimes|mimes:mp3,mp4,mpa|max:4096',
         ], [
             'user_name.required' => '기념인 이름을 입력해 주세요',
             'user_name.max' => '기념인 이름은 50자 이내로 입력해 주세요',
             'birth_start.required' => '기념인 태어난 생년월일을 입력해 주세요',
-            'birth_end.sometimes' => '기념인 돌아간 생년월일을 입력해 주세요',
             'profile.required' => '기념인 프로필 사진을 선택해 주세요',
             'profile.mimes' => '기념인 프로필 사진은 jpg/jpeg/png 형식이여야 합니다',
             'profile.max' => '기념인 프로필 사진은 1Mb 이하여야 합니다',


### PR DESCRIPTION
## 배경
- 정책 변경에 따라 돌아간 년도를 선택사항을 변경해야 합니다. 

## 작업내용
- 커곧내

## 테스트방법
- 기념관 등록/수정시 돌아간 년도가 없어도 등록/수정 되어야 합니다.
