### PR TITLE
기념관 상세 정보 조회 API 에서 로그인한 사용자 이름을 작성자 이름으로 변경하고, 메인 기념과 조회 개수를 4개에서 12개로 변경합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -346,11 +346,11 @@ class MemorialController extends Controller
             ->select('mm_memorials.id', 'mm_memorials.user_id', 'user.user_name', 'mm_memorials.career_contents', 'mm_memorials.profile_attachment_id', 'mm_memorials.bgm_attachment_id')
             ->where('mm_memorials.is_open', 1)
             ->orderBy('mm_memorials.created_at', 'desc')
-            ->limit(4)->get();
+            ->limit(12)->get();
 
         return response()->json([
             'result' => 'success',
-            'message' => '최근 등록된 3개의 기념관 조회가 성공하였습니다.',
+            'message' => '최근 등록된 12개의 기념관 조회가 성공하였습니다.',
             'data' => $memorial
         ]);
     }

--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -311,7 +311,7 @@ class MemorialController extends Controller
 
         $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm', 'story', 'visitComments'])
             ->join('mm_users as user', 'mm_memorials.user_id', 'user.id')
-            ->select('mm_memorials.id', 'user.user_name', 'mm_memorials.birth_start', 'mm_memorials.birth_end', 'mm_memorials.career_contents', 'mm_memorials.is_open', 'mm_memorials.profile_attachment_id', 'mm_memorials.bgm_attachment_id', 'mm_memorials.created_at', 'mm_memorials.updated_at')
+            ->select('mm_memorials.id', 'mm_memorials.name', 'mm_memorials.birth_start', 'mm_memorials.birth_end', 'mm_memorials.career_contents', 'mm_memorials.is_open', 'mm_memorials.profile_attachment_id', 'mm_memorials.bgm_attachment_id', 'mm_memorials.created_at', 'mm_memorials.updated_at')
             ->where('mm_memorials.id', $id)->first();
 
         if (is_null($memorial)) {


### PR DESCRIPTION
## 배경
- QA 수정사항을 반영합니다.
- 기념과 상세 페이지에서 기념관 작성자 이름으로 수정하고, 메인 기념과 조회 개수를 4개에서 12개로 수정합니다.

## 작업내용
- 커곧내

## 테스트방법
- memorial/detail 에서 작성자 이름이 표시되는지 확인합니다.
- memorial/index 에서 총 12개가 조회되는지 확인합니다.
