### PR TITLE
로그인시 구매 요청 정보를 추가합니다.

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -102,7 +102,21 @@ class AuthController extends Controller
         ]);
 
         if ($response->getStatusCode() == 200) {
-            return json_decode((string) $response->getBody(), true);
+            $tokenData = json_decode((string) $response->getBody(), true);
+
+            $user = User::with('purchaseRequests')->where('user_id', $data['user_id'])->first();
+            $isPurchaseRequest = $user ? true : false;
+
+            // 추가로 전달할 데이터
+            $additionalData = [
+                'is_purchase_request' => $isPurchaseRequest,
+                'id' => $user->id,
+                'user_id' => $user->user_id,
+                'user_name' => $user->user_name,
+                'email' => $user->email
+            ];
+
+            return response()->json(array_merge($tokenData, $additionalData));
         } else {
             return response()->json([
                 'code' => $response->getStatusCode(),

--- a/app/Models/PurchaseRequest.php
+++ b/app/Models/PurchaseRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PurchaseRequest extends Model
+{
+    use HasFactory;
+
+    protected $table = 'mm_purchase_requests';
+
+    protected $fillable = [
+        'id',
+        'user_id'
+    ];
+}

--- a/app/Models/PurchaseRequest.php
+++ b/app/Models/PurchaseRequest.php
@@ -15,4 +15,10 @@ class PurchaseRequest extends Model
         'id',
         'user_id'
     ];
+
+        // User와의 관계 정의
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'id', 'user_id');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,4 +66,9 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->where('user_id', $userid)->first();
     }
+
+    public function purchaseRequests()
+    {
+        return $this->hasOne(PurchaseRequest::class, 'user_id', 'id');
+    }
 }

--- a/database/migrations/2025_01_11_080350_add_user_phone_in_mm_users_table.php
+++ b/database/migrations/2025_01_11_080350_add_user_phone_in_mm_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mm_users', function (Blueprint $table) {
+            $table->string('user_phone', 255)->nullable()->comment('전화번호')->after('user_password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mm_users', function (Blueprint $table) {
+            $table->dropColumn('user_phone');
+        });
+    }
+};

--- a/database/migrations/2025_01_11_084844_create_mm_purchase_requests_table.php
+++ b/database/migrations/2025_01_11_084844_create_mm_purchase_requests_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mm_purchase_requests', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->bigIncrements('id')->unique();
+            $table->unsignedBigInteger('user_id')->default(0)->comment('회원 고유키');
+            $table->timestamps();
+            $table->foreign('user_id')->references('id')->on('mm_users')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mm_purchase_requests');
+    }
+};


### PR DESCRIPTION
## 배경
- 로그인시 구매 요청 여부에 따라 구매 요청 화면을 표시해줘야 합니다.

## 작업내용
- 회원테이블에 전화번호 필드를 추가하는 migration 파일을 생성하였습니다.
- 새로운 구매요청 테이블을 생성하는 migration 파일을 생성하였습니다.
- 구매요청 모델을 추가하였습니다.
- 회원과 구매요청 테이블의 연관관계를 정의하였습니다.
- 인증 컨트롤러에서 로그인 성공시 구매요청 정보를 전달하도록 수정하였습니다.

## 테스트방법
- 로컬 개발환경이 없으면 본 PR 이 머지된 후 운영환경에서 로그인시 토큰과 `is_purchase_request` 응답이 전송되어야 합니다.

## 리뷰노트
- 로그인시 토큰 이외 사용자 정보를 추가로 응답값에 추가하였습니다. (id, userId, name, email)
- 머지 후 `php artisan migrate` 명령을 수행해야 합니다.

