### PR TITLE
스토리를 삭제할 수 있습니다.

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -45,4 +45,5 @@ Route::middleware('auth:api')->prefix('memorial')->name('memorial.')->group(func
 
     Route::post('{id}/comment/register', [CommentController::class, 'register'])->name('comment.register');
     Route::post('{id}/story/register', [StoryController::class, 'register'])->name('story.register');
+    Route::post('{id}/story/delete', [StoryController::class, 'delete'])->name('story.delete');
 });


### PR DESCRIPTION
## 배경
- 스토리 삭제 요구사항을 반영합니다.

## 작업내용
- 라우트에 스토리 삭제를 추가하였습니다.
- 컨트롤러에서 스토리 삭제 로직을 구현하였습니다.

## 테스트 방법
- 로그인필요, 아래 포스트맨 참고해주세요
<img width="685" alt="스크린샷 2025-03-09 오후 4 26 53" src="https://github.com/user-attachments/assets/2867ec22-0125-4b73-9223-9162a28103d7" />

## 리뷰노트
- 운영서버에 반영해야 테스트 할 수 있습니다.
