### PR TITLE
리소스 업로드 제한을 Cloudinary 플랜에 맞춰 10M 로 제한합니다.

### DIFF
--- a/app/Http/Controllers/API/MemorialController.php
+++ b/app/Http/Controllers/API/MemorialController.php
@@ -45,7 +45,7 @@ class MemorialController extends Controller
             'user_name' => 'required|max:50',
             'birth_start' => 'required|sometimes|date_format:Y-m-d',
             'profile' => 'required|mimes:jpeg,jpg,png|max:10240',
-            'bgm' => 'sometimes|mimes:mp3,mp4,mpa,m4a|max:102400',
+            'bgm' => 'sometimes|mimes:mp3,mp4,mpa,m4a|max:10240',
         ], [
             'user_name.required' => '기념인 이름을 입력해 주세요',
             'user_name.max' => '기념인 이름은 50자 이내로 입력해 주세요',
@@ -54,7 +54,7 @@ class MemorialController extends Controller
             'profile.mimes' => '기념인 프로필 사진은 jpg/jpeg/png 형식이여야 합니다',
             'profile.max' => '기념인 프로필 사진은 10Mb 이하여야 합니다',
             'bgm.mimes' => '기념관 배경 음악은 mp3, mp4, mpa, m4a 형식이여야 합니다',
-            'bgm.max' => '기념관 배경 음악은 100Mb 이하여야 합니다'
+            'bgm.max' => '기념관 배경 음악은 10Mb 이하여야 합니다'
         ]);
 
         if ($validator->fails()) {
@@ -226,7 +226,7 @@ class MemorialController extends Controller
             'user_name' => 'required|max:50',
             'birth_start' => 'required|sometimes|date_format:Y-m-d',
             'profile' => 'sometimes|mimes:jpeg,jpg,png|max:10240',
-            'bgm' => 'sometimes|mimes:mp3,mp4,mpa,m4a|max:102400',
+            'bgm' => 'sometimes|mimes:mp3,mp4,mpa,m4a|max:10240',
         ], [
             'user_name.required' => '기념인 이름을 입력해 주세요',
             'user_name.max' => '기념인 이름은 50자 이내로 입력해 주세요',
@@ -235,7 +235,7 @@ class MemorialController extends Controller
             'profile.mimes' => '기념인 프로필 사진은 jpg/jpeg/png 형식이여야 합니다',
             'profile.max' => '기념인 프로필 사진은 10Mb 이하여야 합니다',
             'bgm.mimes' => '기념관 배경 음악은 mp3, mp4, mpa, m4a 형식이여야 합니다',
-            'bgm.max' => '기념관 배경 음악은 100Mb 이하여야 합니다'
+            'bgm.max' => '기념관 배경 음악은 10Mb 이하여야 합니다'
         ]);
 
         if ($validator->fails()) {

--- a/app/Http/Controllers/API/StoryController.php
+++ b/app/Http/Controllers/API/StoryController.php
@@ -48,12 +48,12 @@ class StoryController extends Controller
         $validator = Validator::make($request->all(), [
             'title' => 'required|string|max:255',
             'message' => 'required',
-            'attachment' => 'sometimes|max:102400'
+            'attachment' => 'sometimes|max:10240'
         ], [
             'title.required' => '제목을 입력해 주세요',
             'title.max' => '제목은 255자 이내로 입력해 주세요',
             'message.required' => '스토리를 입력해 주세요',
-            'attachment.max' => '첨부파일은 100Mb 이하여야 합니다'
+            'attachment.max' => '첨부파일은 10Mb 이하여야 합니다'
         ]);
 
         if ($validator->fails()) {


### PR DESCRIPTION
## 배경
- cloudinary free 플랜의 최대 업로드 용량은 10M 입니다. 모든 리소스 업로드를 10M 제한합니다.

## 작업내용
- 커곧내

## 테스트 방법
- 10M 이하 이미지, 영상, BGM 이 제한되어야 정상입니다.

## 리뷰노트
- #36 커밋이 포함되어 있습니다.
