### PR TITLE
회원가입 API 유효성 검사 강화 및 응답 데이터를 개선했습니다

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -24,7 +24,7 @@ class AuthController extends Controller
     {
         // 유효성 체크
         $valid = validator($request->only('user_id', 'email', 'user_name', 'user_password'), [
-            'user_id' => 'required|string|max:50|unique:mm_users',
+            'user_id' => 'required|string|min:6|max:50|unique:mm_users',
             'email' => 'required|string|email|max:100|unique:mm_users',
             'user_name' => 'required|string|max:50',
             'user_password' => 'required|string|min:6|max:255'
@@ -57,7 +57,17 @@ class AuthController extends Controller
         ]);
 
         if ($response->getStatusCode() == 200) {
-            return json_decode((string) $response->getBody(), true);
+            $tokenData = json_decode((string) $response->getBody(), true);
+
+            $additionalData = [
+                'id' => $user->id,
+                'user_id' => $user->user_id,
+                'user_name' => $user->user_name,
+                'email' => $user->email,
+                'is_purchase_request' => false,
+            ];
+
+            return response()->json(array_merge($tokenData, $additionalData));
         } else {
             return response()->json([
                 'code' => $response->getStatusCode(),


### PR DESCRIPTION
## 배경
회원가입 시 user_id에 대한 최소 길이 검증이 없었고, 회원가입 성공 응답에 토큰 정보만 반환되어 클라이언트에서 사용자 정보를 별도로 조회해야 하는 불편함이 있었습니다.

## 작업 내용
- `user_id` 필드에 최소 길이(`min:6`) 유효성 검사 추가
- 회원가입 성공 응답에 사용자 정보(`id`, `user_id`, `user_name`, `email`, `is_purchase_request`) 포함

## 리뷰 노트
- `is_purchase_request` 필드는 기본값 `false`로 하드코딩되어 있습니다
- 기존 로그인 API 응답과의 일관성을 확인해주세요