### PR TITLE
메모리얼 어드민 페이지를 구축합니다.

### DIFF
--- a/app/Http/Controllers/Admin/AdminLogController.php
+++ b/app/Http/Controllers/Admin/AdminLogController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminLog;
+use Illuminate\Http\Request;
+
+class AdminLogController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = AdminLog::with('admin');
+
+        if ($type = $request->input('target_type')) {
+            if ($type === '기념관') {
+                $query->whereIn('target_type', ['기념관', '스토리', '방명록']);
+            } elseif ($type === 'AI 질문') {
+                $query->where('target_type', '질문');
+            } else {
+                $query->where('target_type', $type);
+            }
+        }
+
+        $logs = $query->orderBy('created_at', 'desc')->paginate(30)->withQueryString();
+
+        return view('admin.logs.index', compact('logs'));
+    }
+}

--- a/app/Http/Controllers/Admin/CommentController.php
+++ b/app/Http/Controllers/Admin/CommentController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminLog;
+use App\Models\Memorial;
+use App\Models\VisitorComment;
+use Illuminate\Http\Request;
+
+class CommentController extends Controller
+{
+    public function index($id)
+    {
+        $memorial = Memorial::findOrFail($id);
+
+        $comments = VisitorComment::with('user')
+            ->where('memorial_id', $id)
+            ->orderBy('created_at', 'desc')
+            ->paginate(20);
+
+        return view('admin.memorials.comments', compact('memorial', 'comments'));
+    }
+
+    public function toggle($memorialId, $commentId)
+    {
+        $comment = VisitorComment::where('memorial_id', $memorialId)->findOrFail($commentId);
+        $comment->is_visible = $comment->is_visible ? 0 : 1;
+        $comment->save();
+
+        $status = $comment->is_visible ? '노출' : '숨김';
+
+        AdminLog::log('방명록 노출 변경', '방명록', $comment->id, "방명록 #{$comment->id} {$status} 처리");
+
+        return redirect()->route('admin.memorials.comments.index', $memorialId)->with('success', "방명록이 {$status} 처리되었습니다.");
+    }
+
+    public function update(Request $request, $memorialId, $commentId)
+    {
+        $request->validate([
+            'message' => 'required|string|max:5000',
+        ]);
+
+        $comment = VisitorComment::where('memorial_id', $memorialId)->findOrFail($commentId);
+        $comment->message = $request->input('message');
+        $comment->save();
+
+        AdminLog::log('방명록 수정', '방명록', $comment->id, "방명록 #{$comment->id} 내용 변경");
+
+        return redirect()->route('admin.memorials.comments.index', $memorialId)->with('success', '방명록이 수정되었습니다.');
+    }
+
+    public function destroy($memorialId, $commentId)
+    {
+        VisitorComment::where('memorial_id', $memorialId)->findOrFail($commentId)->delete();
+
+        AdminLog::log('방명록 삭제', '방명록', $commentId, "방명록 #{$commentId} 삭제");
+
+        return redirect()->route('admin.memorials.comments.index', $memorialId)->with('success', '방명록이 삭제되었습니다.');
+    }
+}

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Memorial;
+use App\Models\PurchaseRequest;
+use App\Models\Story;
+use App\Models\User;
+use App\Models\VisitorComment;
+use Carbon\Carbon;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $stats = [
+            'total_users' => User::count(),
+            'total_memorials' => Memorial::count(),
+            'total_stories' => Story::count(),
+            'total_comments' => VisitorComment::count(),
+            'total_purchases' => PurchaseRequest::count(),
+            'pending_purchases' => PurchaseRequest::where('status', 'pending')->count(),
+        ];
+
+        // 최근 7일 가입 추이 (단일 쿼리)
+        $startDate = Carbon::today()->subDays(6);
+        $signupCounts = User::selectRaw('DATE(created_at) as signup_date, COUNT(*) as count')
+            ->where('created_at', '>=', $startDate)
+            ->groupByRaw('DATE(created_at)')
+            ->pluck('count', 'signup_date');
+
+        $dailySignups = [];
+        for ($i = 6; $i >= 0; $i--) {
+            $date = Carbon::today()->subDays($i);
+            $dailySignups[] = [
+                'date' => $date->format('m/d'),
+                'count' => $signupCounts[$date->toDateString()] ?? 0,
+            ];
+        }
+
+        $recentUsers = User::orderBy('created_at', 'desc')->limit(5)->get();
+        $recentPurchases = PurchaseRequest::with('user')
+            ->orderBy('created_at', 'desc')
+            ->limit(5)
+            ->get();
+
+        return view('admin.dashboard', compact('stats', 'dailySignups', 'recentUsers', 'recentPurchases'));
+    }
+}

--- a/app/Http/Controllers/Admin/MemorialController.php
+++ b/app/Http/Controllers/Admin/MemorialController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminLog;
+use App\Models\Memorial;
+use App\Models\Story;
+use App\Models\VisitorComment;
+use Illuminate\Http\Request;
+
+class MemorialController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Memorial::with('user');
+
+        if ($search = $request->input('search')) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                  ->orWhereHas('user', function ($q) use ($search) {
+                      $q->where('user_name', 'like', "%{$search}%")
+                        ->orWhere('user_id', 'like', "%{$search}%");
+                  });
+            });
+        }
+
+        $memorials = $query->orderBy('created_at', 'desc')->paginate(20)->withQueryString();
+
+        return view('admin.memorials.index', compact('memorials'));
+    }
+
+    public function show($id)
+    {
+        $memorial = Memorial::with(['attachmentProfileImage', 'attachmentBgm', 'user'])
+            ->withCount(['stories', 'comments'])
+            ->findOrFail($id);
+
+        $owner = $memorial->user;
+        $storyCount = $memorial->stories_count;
+        $commentCount = $memorial->comments_count;
+
+        return view('admin.memorials.show', compact('memorial', 'owner', 'storyCount', 'commentCount'));
+    }
+
+    public function edit($id)
+    {
+        $memorial = Memorial::with('attachmentProfileImage', 'attachmentBgm')->findOrFail($id);
+
+        return view('admin.memorials.edit', compact('memorial'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $memorial = Memorial::findOrFail($id);
+
+        // 기본 정보 수정
+        if ($request->has('name')) {
+            $request->validate([
+                'name' => 'required|string|max:50',
+                'birth_start' => 'nullable|date',
+                'birth_end' => 'nullable|date',
+                'career_contents' => 'nullable|string|max:5000',
+            ]);
+
+            $changes = [];
+            if ($memorial->name !== $request->input('name')) {
+                $changes[] = "기념관명: {$memorial->name} → {$request->input('name')}";
+            }
+            if ((string)$memorial->birth_start !== $request->input('birth_start')) {
+                $changes[] = "출생: " . ($memorial->birth_start ?? '미설정') . " → " . ($request->input('birth_start') ?: '미설정');
+            }
+            if ((string)$memorial->birth_end !== $request->input('birth_end')) {
+                $changes[] = "서거: " . ($memorial->birth_end ?? '미설정') . " → " . ($request->input('birth_end') ?: '미설정');
+            }
+            if ($memorial->career_contents !== $request->input('career_contents')) {
+                $changes[] = "생애 변경";
+            }
+
+            $memorial->name = $request->input('name');
+            $memorial->birth_start = $request->input('birth_start') ?: null;
+            $memorial->birth_end = $request->input('birth_end') ?: null;
+            $memorial->career_contents = $request->input('career_contents');
+            $memorial->save();
+
+            if ($changes) {
+                AdminLog::log('기념관 정보 수정', '기념관', $memorial->id, implode(', ', $changes));
+            }
+
+            return redirect()->route('admin.memorials.edit', $id)->with('success', '기념관 정보가 수정되었습니다.');
+        }
+
+        // 공개 설정 변경
+        if ($request->has('is_open')) {
+            $memorial->is_open = $request->boolean('is_open') ? 1 : 0;
+            $memorial->save();
+
+            AdminLog::log('기념관 설정 수정', '기념관', $memorial->id, "{$memorial->name} 공개설정 변경");
+        }
+
+        return redirect()->back()->with('success', '기념관 설정이 수정되었습니다.');
+    }
+
+    public function destroy($id)
+    {
+        $memorial = Memorial::findOrFail($id);
+
+        // 연관 데이터 삭제
+        Story::where('memorial_id', $id)->delete();
+        VisitorComment::where('memorial_id', $id)->delete();
+
+        AdminLog::log('기념관 삭제', '기념관', $memorial->id, "{$memorial->name} 기념관 삭제");
+
+        $memorial->delete();
+
+        return redirect()->route('admin.memorials.index')->with('success', '기념관이 삭제되었습니다.');
+    }
+}

--- a/app/Http/Controllers/Admin/PurchaseRequestController.php
+++ b/app/Http/Controllers/Admin/PurchaseRequestController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminLog;
+use App\Models\PurchaseRequest;
+use Illuminate\Http\Request;
+
+class PurchaseRequestController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = PurchaseRequest::with('user', 'processor');
+
+        if ($status = $request->input('status')) {
+            $query->where('status', $status);
+        }
+
+        $purchases = $query->orderBy('created_at', 'desc')->paginate(20)->withQueryString();
+
+        return view('admin.purchases.index', compact('purchases'));
+    }
+
+    public function updateStatus(Request $request, $id)
+    {
+        $request->validate([
+            'status' => 'required|in:pending,approved,rejected',
+            'admin_memo' => 'nullable|string|max:1000',
+        ]);
+
+        $purchase = PurchaseRequest::findOrFail($id);
+        $purchase->update([
+            'status' => $request->input('status'),
+            'admin_memo' => $request->input('admin_memo'),
+            'processed_at' => now(),
+            'processed_by' => $request->user()->id,
+        ]);
+
+        $statusLabels = ['approved' => '승인', 'rejected' => '거절', 'pending' => '대기'];
+
+        AdminLog::log('구매요청 상태 변경', '구매요청', $purchase->id, "구매요청 #{$purchase->id} → {$statusLabels[$request->input('status')]}");
+
+        return redirect()->back()->with('success', "구매 신청이 {$statusLabels[$request->input('status')]}되었습니다.");
+    }
+
+    public function destroy($id)
+    {
+        PurchaseRequest::findOrFail($id)->delete();
+
+        AdminLog::log('구매요청 삭제', '구매요청', $id, "구매요청 #{$id} 삭제");
+
+        return redirect()->route('admin.purchases.index')->with('success', '구매 신청이 삭제되었습니다.');
+    }
+}

--- a/app/Http/Controllers/Admin/QuestionController.php
+++ b/app/Http/Controllers/Admin/QuestionController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminLog;
+use App\Models\MemorialQuestion;
+use App\Models\MemorialQuestionDetail;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class QuestionController extends Controller
+{
+    public function index()
+    {
+        $questions = MemorialQuestion::with('detail')
+            ->orderBy('display_order', 'asc')
+            ->get();
+
+        return view('admin.questions.index', compact('questions'));
+    }
+
+    public function create()
+    {
+        return view('admin.questions.edit', [
+            'question' => null,
+            'detail' => null,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'question_type' => 'required|string|max:50',
+            'question_title' => 'required|string|max:255',
+            'display_order' => 'required|integer|min:0',
+            'is_active' => 'required|boolean',
+        ]);
+
+        $question = DB::transaction(function () use ($request) {
+            $detail = MemorialQuestionDetail::create([
+                'question_type' => $request->input('question_type'),
+                'question_title' => $request->input('question_title'),
+            ]);
+
+            return MemorialQuestion::create([
+                'detail_id' => $detail->id,
+                'display_order' => $request->input('display_order'),
+                'is_active' => $request->input('is_active'),
+            ]);
+        });
+
+        AdminLog::log('질문 추가', '질문', $question->id, "{$request->input('question_title')} 질문 추가");
+
+        return redirect()->route('admin.questions.index')->with('success', '질문이 추가되었습니다.');
+    }
+
+    public function edit($id)
+    {
+        $question = MemorialQuestion::with('detail')->findOrFail($id);
+        $detail = $question->detail;
+
+        return view('admin.questions.edit', compact('question', 'detail'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $request->validate([
+            'question_type' => 'required|string|max:50',
+            'question_title' => 'required|string|max:255',
+            'display_order' => 'required|integer|min:0',
+            'is_active' => 'required|boolean',
+        ]);
+
+        $question = MemorialQuestion::with('detail')->findOrFail($id);
+
+        // 필수 질문(1, 2번)은 순서 변경 불가
+        $isRequired = in_array($question->display_order, [1, 2]);
+
+        DB::transaction(function () use ($request, $question, $isRequired) {
+            $question->detail->update([
+                'question_type' => $request->input('question_type'),
+                'question_title' => $request->input('question_title'),
+            ]);
+
+            $updateData = ['is_active' => $request->input('is_active')];
+            if (!$isRequired) {
+                $updateData['display_order'] = $request->input('display_order');
+            }
+            $question->update($updateData);
+        });
+
+        AdminLog::log('질문 수정', '질문', $question->id, "{$request->input('question_title')} 질문 수정");
+
+        return redirect()->route('admin.questions.index')->with('success', '질문이 수정되었습니다.');
+    }
+
+    public function destroy($id)
+    {
+        $question = MemorialQuestion::with('detail')->findOrFail($id);
+
+        if (in_array($question->display_order, [1, 2])) {
+            return redirect()->back()->with('error', '필수 질문은 삭제할 수 없습니다.');
+        }
+
+        $questionId = $question->id;
+        $questionTitle = $question->detail?->question_title ?? '';
+
+        DB::transaction(function () use ($question) {
+            $question->delete();
+            if ($question->detail) {
+                $question->detail->delete();
+            }
+        });
+
+        AdminLog::log('질문 삭제', '질문', $questionId, "{$questionTitle} 질문 삭제");
+
+        return redirect()->route('admin.questions.index')->with('success', '질문이 삭제되었습니다.');
+    }
+}

--- a/app/Http/Controllers/Admin/StoryController.php
+++ b/app/Http/Controllers/Admin/StoryController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminLog;
+use App\Models\Memorial;
+use App\Models\Story;
+use Illuminate\Http\Request;
+
+class StoryController extends Controller
+{
+    public function index($id)
+    {
+        $memorial = Memorial::findOrFail($id);
+
+        $stories = Story::with('user')
+            ->where('memorial_id', $id)
+            ->orderBy('created_at', 'desc')
+            ->paginate(20);
+
+        return view('admin.memorials.stories', compact('memorial', 'stories'));
+    }
+
+    public function toggle($memorialId, $storyId)
+    {
+        $story = Story::where('memorial_id', $memorialId)->findOrFail($storyId);
+        $story->is_visible = $story->is_visible ? 0 : 1;
+        $story->save();
+
+        $status = $story->is_visible ? '노출' : '숨김';
+
+        AdminLog::log('스토리 노출 변경', '스토리', $story->id, "스토리 #{$story->id} {$status} 처리");
+
+        return redirect()->route('admin.memorials.stories.index', $memorialId)->with('success', "스토리가 {$status} 처리되었습니다.");
+    }
+
+    public function update(Request $request, $memorialId, $storyId)
+    {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'message' => 'nullable|string|max:10000',
+        ]);
+
+        $story = Story::where('memorial_id', $memorialId)->findOrFail($storyId);
+
+        $changes = [];
+        if ($story->title !== $request->input('title')) {
+            $changes[] = "제목: {$story->title} → {$request->input('title')}";
+        }
+        if ($story->message !== $request->input('message')) {
+            $changes[] = "내용 변경";
+        }
+
+        $story->title = $request->input('title');
+        $story->message = $request->input('message');
+        $story->save();
+
+        if ($changes) {
+            AdminLog::log('스토리 수정', '스토리', $story->id, "스토리 #{$story->id} " . implode(', ', $changes));
+        }
+
+        return redirect()->route('admin.memorials.stories.index', $memorialId)->with('success', '스토리가 수정되었습니다.');
+    }
+
+    public function destroy($memorialId, $storyId)
+    {
+        Story::where('memorial_id', $memorialId)->findOrFail($storyId)->delete();
+
+        AdminLog::log('스토리 삭제', '스토리', $storyId, "스토리 #{$storyId} 삭제");
+
+        return redirect()->route('admin.memorials.stories.index', $memorialId)->with('success', '스토리가 삭제되었습니다.');
+    }
+}

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Memorial;
+use App\Models\Story;
+use App\Models\User;
+use App\Models\AdminLog;
+use App\Models\VisitorComment;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = User::query();
+
+        // 슈퍼관리자(admin)는 본인 로그인 시에만 목록에 표시
+        if (auth()->user()->user_id !== 'admin') {
+            $query->where('user_id', '!=', 'admin');
+        }
+
+        if ($search = $request->input('search')) {
+            $query->where(function ($q) use ($search) {
+                $q->where('user_id', 'like', "%{$search}%")
+                  ->orWhere('user_name', 'like', "%{$search}%")
+                  ->orWhere('email', 'like', "%{$search}%");
+            });
+        }
+
+        if ($request->input('filter') === 'admin') {
+            $query->where('is_admin', 1);
+        } elseif ($request->input('filter') === 'normal') {
+            $query->where('is_admin', 0);
+        } elseif ($request->input('filter') === 'dormancy') {
+            $query->where('is_dormancy', 1);
+        } elseif ($request->input('filter') === 'withdraw') {
+            $query->where('is_withdraw', 1);
+        } elseif ($request->input('filter') === 'trial') {
+            $query->where('is_trial', 1);
+        }
+
+        $users = $query->orderBy('created_at', 'desc')->paginate(20)->withQueryString();
+
+        return view('admin.users.index', compact('users'));
+    }
+
+    public function show($id)
+    {
+        $user = User::with('memorial', 'purchaseRequests')->findOrFail($id);
+
+        return view('admin.users.show', compact('user'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $user = User::findOrFail($id);
+
+        // 기본 정보 수정
+        if ($request->has('user_name')) {
+            $request->validate([
+                'user_name' => 'required|string|max:50',
+                'user_id' => "required|string|max:50|unique:mm_users,user_id,{$user->id}",
+                'email' => "required|email|max:100|unique:mm_users,email,{$user->id}",
+            ]);
+
+            $changes = [];
+            if ($user->user_name !== $request->input('user_name')) {
+                $changes[] = "이름: {$user->user_name} → {$request->input('user_name')}";
+                $user->user_name = $request->input('user_name');
+            }
+            if ($user->user_id !== $request->input('user_id')) {
+                $changes[] = "아이디: {$user->user_id} → {$request->input('user_id')}";
+                $user->user_id = $request->input('user_id');
+            }
+            if ($user->email !== $request->input('email')) {
+                $changes[] = "이메일: {$user->email} → {$request->input('email')}";
+                $user->email = $request->input('email');
+            }
+
+            $user->save();
+
+            if ($changes) {
+                AdminLog::log('회원 정보 수정', '회원', $user->id, implode(', ', $changes));
+            }
+
+            return redirect()->back()->with('success', '회원 정보가 수정되었습니다.');
+        }
+
+        // 상태 관리
+        if ($request->has('is_admin')) {
+            $user->is_admin = $request->boolean('is_admin') ? 1 : 0;
+        }
+        if ($request->has('is_dormancy')) {
+            $user->is_dormancy = $request->boolean('is_dormancy') ? 1 : 0;
+        }
+        if ($request->has('is_withdraw')) {
+            $user->is_withdraw = $request->boolean('is_withdraw') ? 1 : 0;
+        }
+
+        $user->save();
+
+        AdminLog::log('회원 상태 수정', '회원', $user->id, "{$user->user_id} 회원 상태 수정");
+
+        return redirect()->back()->with('success', '회원 상태가 수정되었습니다.');
+    }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+
+        // 슈퍼관리자 삭제 방지
+        if ($user->user_id === 'admin') {
+            return redirect()->back()->with('error', '슈퍼관리자는 삭제할 수 없습니다.');
+        }
+
+        // 관련 데이터 삭제 (기념관 → 스토리/방명록)
+        $memorial = Memorial::where('user_id', $user->id)->first();
+        if ($memorial) {
+            Story::where('memorial_id', $memorial->id)->delete();
+            VisitorComment::where('memorial_id', $memorial->id)->delete();
+            $memorial->delete();
+        }
+
+        // 회원이 작성한 스토리/방명록도 삭제
+        Story::where('user_id', $user->id)->delete();
+        VisitorComment::where('user_id', $user->id)->delete();
+
+        AdminLog::log('회원 삭제', '회원', $user->id, "{$user->user_id} 회원 삭제");
+
+        $user->delete();
+
+        return redirect()->route('admin.users.index')->with('success', '회원이 삭제되었습니다.');
+    }
+}

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -27,6 +27,16 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
+        if (!Auth::user()->isAdmin()) {
+            Auth::guard('web')->logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'user_id' => '관리자 권한이 없습니다.',
+            ]);
+        }
+
         $request->session()->regenerate();
 
         return redirect()->intended(RouteServiceProvider::HOME);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'admin' => \App\Http\Middleware\EnsureIsAdmin::class,
     ];
 }

--- a/app/Http/Middleware/EnsureIsAdmin.php
+++ b/app/Http/Middleware/EnsureIsAdmin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureIsAdmin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (!$request->user() || !$request->user()->isAdmin()) {
+            abort(403, '관리자 권한이 없습니다.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -27,7 +27,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
+            'user_id' => ['required', 'string'],
             'password' => ['required', 'string'],
         ];
     }
@@ -41,11 +41,11 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        if (! Auth::attempt(['user_id' => $this->input('user_id'), 'password' => $this->input('password')], $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
-                'email' => trans('auth.failed'),
+                'user_id' => '아이디 또는 비밀번호가 일치하지 않습니다.',
             ]);
         }
 
@@ -68,7 +68,7 @@ class LoginRequest extends FormRequest
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages([
-            'email' => trans('auth.throttle', [
+            'user_id' => trans('auth.throttle', [
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ]),
@@ -80,6 +80,6 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->input('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->input('user_id')).'|'.$this->ip());
     }
 }

--- a/app/Models/AdminLog.php
+++ b/app/Models/AdminLog.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AdminLog extends Model
+{
+    protected $table = 'mm_admin_logs';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'admin_id',
+        'action',
+        'target_type',
+        'target_id',
+        'description',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function admin()
+    {
+        return $this->belongsTo(User::class, 'admin_id', 'id');
+    }
+
+    public static function log(string $action, string $targetType, int $targetId, string $description = ''): self
+    {
+        return self::create([
+            'admin_id' => auth()->id(),
+            'action' => $action,
+            'target_type' => $targetType,
+            'target_id' => $targetId,
+            'description' => $description,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/Memorial.php
+++ b/app/Models/Memorial.php
@@ -21,8 +21,20 @@ class Memorial extends Model
         return $this->hasOne(Attachment::class, 'id', 'bgm_attachment_id')->where('is_delete', 0);
     }
 
+    public function user() {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
+
+    public function stories() {
+        return $this->hasMany(Story::class, 'memorial_id', 'id');
+    }
+
     public function story() {
         return $this->hasMany(Story::class, 'memorial_id', 'id')->where('is_visible', 1);
+    }
+
+    public function comments() {
+        return $this->hasMany(VisitorComment::class, 'memorial_id', 'id');
     }
 
     public function visitComments() {

--- a/app/Models/PurchaseRequest.php
+++ b/app/Models/PurchaseRequest.php
@@ -13,12 +13,20 @@ class PurchaseRequest extends Model
 
     protected $fillable = [
         'id',
-        'user_id'
+        'user_id',
+        'status',
+        'admin_memo',
+        'processed_at',
+        'processed_by',
     ];
 
-        // User와의 관계 정의
     public function user()
     {
-        return $this->belongsTo(User::class, 'id', 'user_id');
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
+
+    public function processor()
+    {
+        return $this->belongsTo(User::class, 'processed_by', 'id');
     }
 }

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -14,4 +14,8 @@ class Story extends Model
     public function attachment() {
         return $this->hasOne(Attachment::class, 'id', 'attachment_id')->where('is_delete', 0);
     }
+
+    public function user() {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,7 +25,18 @@ class User extends Authenticatable implements MustVerifyEmail
         'user_name',
         'email',
         'user_password',
+        'is_admin',
     ];
+
+    public function isAdmin(): bool
+    {
+        return (bool) $this->is_admin;
+    }
+
+    public function memorial()
+    {
+        return $this->hasOne(Memorial::class, 'user_id', 'id');
+    }
 
     /**
      * The attributes that should be hidden for serialization.
@@ -69,6 +80,6 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function purchaseRequests()
     {
-        return $this->hasOne(PurchaseRequest::class, 'user_id', 'id');
+        return $this->hasMany(PurchaseRequest::class, 'user_id', 'id');
     }
 }

--- a/app/Models/VisitorComment.php
+++ b/app/Models/VisitorComment.php
@@ -11,4 +11,8 @@ class VisitorComment extends Model
 
     protected $table = "mm_visitor_comments";
     public $timestamps = true;
+
+    public function user() {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/admin/dashboard';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,7 +3,7 @@ server {
         root /var/www/html/public;
         index index.html index.htm index.php;
 
-        server_name localhost;
+        server_name localhost admin.yourmemorial.kr;
 
     	error_log  /var/log/nginx/error.log;
 	    access_log /var/log/nginx/access.log;

--- a/database/migrations/2026_02_28_000001_add_is_admin_to_mm_users_table.php
+++ b/database/migrations/2026_02_28_000001_add_is_admin_to_mm_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('mm_users', function (Blueprint $table) {
+            $table->unsignedTinyInteger('is_admin')->default(0)->after('user_password');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('mm_users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/database/migrations/2026_02_28_000002_add_status_to_mm_purchase_requests_table.php
+++ b/database/migrations/2026_02_28_000002_add_status_to_mm_purchase_requests_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('mm_purchase_requests', function (Blueprint $table) {
+            $table->string('status', 20)->default('pending')->after('user_id');
+            $table->text('admin_memo')->nullable()->after('status');
+            $table->timestamp('processed_at')->nullable()->after('admin_memo');
+            $table->unsignedBigInteger('processed_by')->nullable()->after('processed_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('mm_purchase_requests', function (Blueprint $table) {
+            $table->dropColumn(['status', 'admin_memo', 'processed_at', 'processed_by']);
+        });
+    }
+};

--- a/database/migrations/2026_02_28_000003_create_mm_admin_logs_table.php
+++ b/database/migrations/2026_02_28_000003_create_mm_admin_logs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('mm_admin_logs', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('admin_id')->comment('관리자 고유키');
+            $table->string('action', 100)->comment('행위');
+            $table->string('target_type', 50)->comment('대상 종류');
+            $table->unsignedBigInteger('target_id')->comment('대상 ID');
+            $table->string('description', 500)->default('')->comment('상세 설명');
+            $table->timestamp('created_at')->nullable();
+
+            $table->foreign('admin_id')->references('id')->on('mm_users')->cascadeOnDelete();
+            $table->index(['target_type', 'created_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('mm_admin_logs');
+    }
+};

--- a/database/migrations/2026_03_01_000001_add_indexes_to_foreign_key_columns.php
+++ b/database/migrations/2026_03_01_000001_add_indexes_to_foreign_key_columns.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('mm_memorials', function (Blueprint $table) {
+            $table->index('user_id');
+        });
+
+        Schema::table('mm_stories', function (Blueprint $table) {
+            $table->index('memorial_id');
+            $table->index('user_id');
+        });
+
+        Schema::table('mm_visitor_comments', function (Blueprint $table) {
+            $table->index('memorial_id');
+            $table->index('user_id');
+        });
+
+        Schema::table('mm_purchase_requests', function (Blueprint $table) {
+            $table->index('user_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('mm_memorials', function (Blueprint $table) {
+            $table->dropIndex(['user_id']);
+        });
+
+        Schema::table('mm_stories', function (Blueprint $table) {
+            $table->dropIndex(['memorial_id']);
+            $table->dropIndex(['user_id']);
+        });
+
+        Schema::table('mm_visitor_comments', function (Blueprint $table) {
+            $table->dropIndex(['memorial_id']);
+            $table->dropIndex(['user_id']);
+        });
+
+        Schema::table('mm_purchase_requests', function (Blueprint $table) {
+            $table->dropIndex(['user_id']);
+        });
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class AdminUserSeeder extends Seeder
+{
+    public function run()
+    {
+        User::updateOrCreate(
+            ['user_id' => 'admin'],
+            [
+                'user_name' => '관리자',
+                'email' => 'admin@yourmemorial.kr',
+                'user_password' => Hash::make('admin1234!'),
+                'is_admin' => 1,
+            ]
+        );
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,190 @@
+<x-admin-layout title="대시보드">
+    {{-- Stats Cards --}}
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4 mb-8">
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-xs sm:text-sm text-gray-500">총 회원</p>
+                    <p class="text-xl sm:text-3xl font-bold text-[#2c2520] mt-1">{{ number_format($stats['total_users']) }}</p>
+                </div>
+                <div class="w-10 h-10 sm:w-12 sm:h-12 bg-blue-50 rounded-lg flex items-center justify-center">
+                    <svg class="w-5 h-5 sm:w-6 sm:h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-xs sm:text-sm text-gray-500">총 기념관</p>
+                    <p class="text-xl sm:text-3xl font-bold text-[#2c2520] mt-1">{{ number_format($stats['total_memorials']) }}</p>
+                </div>
+                <div class="w-10 h-10 sm:w-12 sm:h-12 bg-amber-50 rounded-lg flex items-center justify-center">
+                    <svg class="w-5 h-5 sm:w-6 sm:h-6 text-[#c8952e]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-xs sm:text-sm text-gray-500">총 스토리</p>
+                    <p class="text-xl sm:text-3xl font-bold text-[#2c2520] mt-1">{{ number_format($stats['total_stories']) }}</p>
+                </div>
+                <div class="w-10 h-10 sm:w-12 sm:h-12 bg-green-50 rounded-lg flex items-center justify-center">
+                    <svg class="w-5 h-5 sm:w-6 sm:h-6 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-xs sm:text-sm text-gray-500">총 방명록</p>
+                    <p class="text-xl sm:text-3xl font-bold text-[#2c2520] mt-1">{{ number_format($stats['total_comments']) }}</p>
+                </div>
+                <div class="w-10 h-10 sm:w-12 sm:h-12 bg-purple-50 rounded-lg flex items-center justify-center">
+                    <svg class="w-5 h-5 sm:w-6 sm:h-6 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-xs sm:text-sm text-gray-500">총 구매 신청</p>
+                    <p class="text-xl sm:text-3xl font-bold text-[#2c2520] mt-1">{{ number_format($stats['total_purchases']) }}</p>
+                </div>
+                <div class="w-10 h-10 sm:w-12 sm:h-12 bg-orange-50 rounded-lg flex items-center justify-center">
+                    <svg class="w-5 h-5 sm:w-6 sm:h-6 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-xs sm:text-sm text-gray-500">대기중 구매</p>
+                    <p class="text-xl sm:text-3xl font-bold text-[#c8952e] mt-1">{{ number_format($stats['pending_purchases']) }}</p>
+                </div>
+                <div class="w-10 h-10 sm:w-12 sm:h-12 bg-yellow-50 rounded-lg flex items-center justify-center">
+                    <svg class="w-5 h-5 sm:w-6 sm:h-6 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- Charts & Tables Row --}}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {{-- Daily Signups Chart --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <h3 class="text-sm font-semibold text-[#2c2520] mb-4">최근 7일 가입 추이</h3>
+            <div class="flex items-end gap-1 sm:gap-2 h-40">
+                @php $maxCount = max(1, ...array_column($dailySignups, 'count')); @endphp
+                @foreach($dailySignups as $day)
+                    <div class="flex-1 flex flex-col items-center gap-1">
+                        <span class="text-xs text-gray-500">{{ $day['count'] }}</span>
+                        <div class="w-full bg-[#c8952e]/20 rounded-t" style="height: {{ ($day['count'] / $maxCount) * 100 }}%">
+                            <div class="w-full h-full bg-[#c8952e] rounded-t min-h-[4px]"></div>
+                        </div>
+                        <span class="text-[10px] sm:text-xs text-gray-400">{{ $day['date'] }}</span>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- Recent Users --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-sm font-semibold text-[#2c2520]">최근 가입 회원</h3>
+                <a href="{{ route('admin.users.index') }}" class="text-xs text-[#c8952e] hover:underline">전체 보기</a>
+            </div>
+            <div class="space-y-3">
+                @forelse($recentUsers as $user)
+                    <div class="flex items-center justify-between py-2 border-b border-gray-50 last:border-0">
+                        <div>
+                            <p class="text-sm font-medium text-gray-900">{{ $user->user_name }}</p>
+                            <p class="text-xs text-gray-400">{{ $user->user_id }}</p>
+                        </div>
+                        <span class="text-xs text-gray-400">{{ $user->created_at->format('Y-m-d') }}</span>
+                    </div>
+                @empty
+                    <p class="text-sm text-gray-400">가입 회원이 없습니다.</p>
+                @endforelse
+            </div>
+        </div>
+    </div>
+
+    {{-- Recent Purchases --}}
+    <div class="mt-6 bg-white rounded-xl shadow-sm border border-gray-100 p-4 sm:p-6">
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-sm font-semibold text-[#2c2520]">최근 구매 신청</h3>
+            <a href="{{ route('admin.purchases.index') }}" class="text-xs text-[#c8952e] hover:underline">전체 보기</a>
+        </div>
+
+        {{-- Desktop Table --}}
+        <div class="hidden sm:block overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-gray-100">
+                        <th class="text-left py-2 px-3 text-gray-500 font-medium">회원</th>
+                        <th class="text-left py-2 px-3 text-gray-500 font-medium">상태</th>
+                        <th class="text-left py-2 px-3 text-gray-500 font-medium">신청일</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($recentPurchases as $purchase)
+                        <tr class="border-b border-gray-50 last:border-0">
+                            <td class="py-2.5 px-3">{{ $purchase->user->user_name ?? '-' }}</td>
+                            <td class="py-2.5 px-3">
+                                @if($purchase->status === 'pending')
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">대기</span>
+                                @elseif($purchase->status === 'approved')
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">승인</span>
+                                @else
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">거절</span>
+                                @endif
+                            </td>
+                            <td class="py-2.5 px-3 text-gray-400">{{ $purchase->created_at->format('Y-m-d H:i') }}</td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="3" class="py-4 text-center text-gray-400">구매 신청이 없습니다.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        {{-- Mobile List --}}
+        <div class="sm:hidden space-y-2">
+            @forelse($recentPurchases as $purchase)
+                <div class="flex items-center justify-between py-2 border-b border-gray-50 last:border-0">
+                    <div>
+                        <p class="text-sm font-medium text-gray-900">{{ $purchase->user->user_name ?? '-' }}</p>
+                        <p class="text-xs text-gray-400">{{ $purchase->created_at->format('Y-m-d H:i') }}</p>
+                    </div>
+                    @if($purchase->status === 'pending')
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">대기</span>
+                    @elseif($purchase->status === 'approved')
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">승인</span>
+                    @else
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">거절</span>
+                    @endif
+                </div>
+            @empty
+                <p class="py-4 text-center text-sm text-gray-400">구매 신청이 없습니다.</p>
+            @endforelse
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/layouts/navigation.blade.php
+++ b/resources/views/admin/layouts/navigation.blade.php
@@ -1,0 +1,76 @@
+@php
+    $currentRoute = Route::currentRouteName();
+@endphp
+
+<aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-[#2c2520] text-white transform -translate-x-full lg:translate-x-0 transition-transform duration-200 ease-in-out">
+    {{-- Logo --}}
+    <div class="flex items-center gap-3 px-6 py-5 border-b border-white/10">
+        <div class="w-8 h-8 rounded-full bg-[#c8952e] flex items-center justify-center">
+            <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 2a1 1 0 011 1v1.323l3.954 1.582 1.599-.8a1 1 0 01.894 1.79l-1.233.616 1.738 5.42a1 1 0 01-.285 1.05A3.989 3.989 0 0115 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.715-5.349L10 6.2V16h3a1 1 0 110 2H7a1 1 0 110-2h3V6.2L6.237 7.582l1.715 5.349a1 1 0 01-.285 1.05A3.989 3.989 0 015 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.738-5.42-1.233-.617a1 1 0 01.894-1.788l1.599.799L9 4.323V3a1 1 0 011-1z"/>
+            </svg>
+        </div>
+        <span class="text-lg font-bold">메모리얼 Admin</span>
+    </div>
+
+    {{-- Navigation --}}
+    <nav class="mt-4 px-3 space-y-1">
+        <a href="{{ route('admin.dashboard') }}"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition
+                  {{ Str::startsWith($currentRoute, 'admin.dashboard') ? 'bg-[#c8952e] text-white' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+            </svg>
+            대시보드
+        </a>
+
+        <a href="{{ route('admin.users.index') }}"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition
+                  {{ Str::startsWith($currentRoute, 'admin.users') ? 'bg-[#c8952e] text-white' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+            </svg>
+            회원 관리
+        </a>
+
+        <a href="{{ route('admin.memorials.index') }}"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition
+                  {{ Str::startsWith($currentRoute, 'admin.memorials') ? 'bg-[#c8952e] text-white' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+            </svg>
+            기념관 관리
+        </a>
+
+        <a href="{{ route('admin.purchases.index') }}"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition
+                  {{ Str::startsWith($currentRoute, 'admin.purchases') ? 'bg-[#c8952e] text-white' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"/>
+            </svg>
+            구매 신청
+        </a>
+
+        <a href="{{ route('admin.questions.index') }}"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition
+                  {{ Str::startsWith($currentRoute, 'admin.questions') ? 'bg-[#c8952e] text-white' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            질문 관리
+        </a>
+
+        <a href="{{ route('admin.logs.index') }}"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition
+                  {{ Str::startsWith($currentRoute, 'admin.logs') ? 'bg-[#c8952e] text-white' : 'text-gray-300 hover:bg-white/10 hover:text-white' }}">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+            </svg>
+            활동 로그
+        </a>
+    </nav>
+</aside>
+
+{{-- Mobile overlay --}}
+<div onclick="document.getElementById('sidebar').classList.add('-translate-x-full')"
+     class="fixed inset-0 bg-black/50 z-10 lg:hidden hidden" id="sidebar-overlay"></div>

--- a/resources/views/admin/logs/index.blade.php
+++ b/resources/views/admin/logs/index.blade.php
@@ -1,0 +1,106 @@
+<x-admin-layout title="활동 로그">
+
+    {{-- Header --}}
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <h1 class="text-2xl font-bold text-[#2c2520]">활동 로그</h1>
+    </div>
+
+    @php
+        $labelStyles = [
+            '전체'   => ['bg' => '#f3f4f6', 'color' => '#374151', 'ring' => '#6b7280'],
+            '회원'   => ['bg' => '#dbeafe', 'color' => '#1e40af', 'ring' => '#3b82f6'],
+            '기념관'  => ['bg' => '#f3e8ff', 'color' => '#6b21a8', 'ring' => '#a855f7'],
+            '구매요청' => ['bg' => '#fee2e2', 'color' => '#991b1b', 'ring' => '#ef4444'],
+            'AI 질문' => ['bg' => '#e0e7ff', 'color' => '#3730a3', 'ring' => '#6366f1'],
+        ];
+        $current = request('target_type', '');
+        $filterKeys = ['' => '전체', '회원' => '회원', '기념관' => '기념관', '구매요청' => '구매요청', 'AI 질문' => 'AI 질문'];
+    @endphp
+
+    {{-- Filter --}}
+    <div class="flex flex-wrap gap-2 mb-6">
+        @foreach($filterKeys as $value => $label)
+            @php $s = $labelStyles[$label]; @endphp
+            <a href="{{ route('admin.logs.index', $value ? ['target_type' => $value] : []) }}"
+               style="background-color: {{ $s['bg'] }}; color: {{ $s['color'] }};{{ $current === $value ? ' box-shadow: 0 0 0 2px #fff, 0 0 0 4px ' . $s['ring'] . ';' : '' }}"
+               class="inline-block px-3 py-1 rounded-full text-xs font-semibold transition hover:opacity-80">
+                {{ $label }}
+            </a>
+        @endforeach
+    </div>
+
+    {{-- Desktop Table --}}
+    <div class="hidden md:block bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+        <table class="w-full text-sm">
+            <thead class="bg-gray-50 text-gray-600">
+                <tr>
+                    <th class="px-6 py-3 text-left font-medium">일시</th>
+                    <th class="px-6 py-3 text-left font-medium">관리자</th>
+                    <th class="px-6 py-3 text-left font-medium">대상</th>
+                    <th class="px-6 py-3 text-left font-medium">행위</th>
+                    <th class="px-6 py-3 text-left font-medium">상세</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @forelse($logs as $log)
+                    @php
+                        $displayType = match($log->target_type) {
+                            '스토리', '방명록' => '기념관',
+                            '질문' => 'AI 질문',
+                            default => $log->target_type,
+                        };
+                        $s = $labelStyles[$displayType] ?? $labelStyles['전체'];
+                    @endphp
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-3 text-gray-500 whitespace-nowrap">{{ $log->created_at->format('Y-m-d H:i') }}</td>
+                        <td class="px-6 py-3 text-[#2c2520]">{{ $log->admin?->user_id ?? '-' }}</td>
+                        <td class="px-6 py-3">
+                            <span class="inline-block px-3 py-1 rounded-full text-xs font-semibold" style="background-color: {{ $s['bg'] }}; color: {{ $s['color'] }};">{{ $displayType }}</span>
+                        </td>
+                        <td class="px-6 py-3 text-[#2c2520] font-medium">{{ $log->action }}</td>
+                        <td class="px-6 py-3 text-gray-600">{{ $log->description }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="5" class="px-6 py-12 text-center text-gray-400">활동 로그가 없습니다.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    {{-- Mobile Cards --}}
+    <div class="md:hidden space-y-3">
+        @forelse($logs as $log)
+            @php
+                $displayType = match($log->target_type) {
+                    '스토리', '방명록' => '기념관',
+                    '질문' => 'AI 질문',
+                    default => $log->target_type,
+                };
+                $s = $labelStyles[$displayType] ?? $labelStyles['전체'];
+            @endphp
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+                <div class="flex items-center justify-between mb-2">
+                    <span class="inline-block px-3 py-1 rounded-full text-xs font-semibold" style="background-color: {{ $s['bg'] }}; color: {{ $s['color'] }};">{{ $displayType }}</span>
+                    <span class="text-xs text-gray-400">{{ $log->created_at->format('Y-m-d H:i') }}</span>
+                </div>
+                <p class="text-sm font-medium text-[#2c2520] mb-1">{{ $log->action }}</p>
+                <p class="text-sm text-gray-600 mb-2">{{ $log->description }}</p>
+                <p class="text-xs text-gray-400">관리자: {{ $log->admin?->user_id ?? '-' }}</p>
+            </div>
+        @empty
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">
+                활동 로그가 없습니다.
+            </div>
+        @endforelse
+    </div>
+
+    {{-- Pagination --}}
+    @if($logs->hasPages())
+        <div class="mt-6">
+            {{ $logs->links() }}
+        </div>
+    @endif
+
+</x-admin-layout>

--- a/resources/views/admin/memorials/comments.blade.php
+++ b/resources/views/admin/memorials/comments.blade.php
@@ -1,0 +1,152 @@
+<x-admin-layout title="{{ $memorial->name }}의 방명록">
+    <div>
+        <a href="{{ route('admin.memorials.show', $memorial->id) }}" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#c8952e] mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+            기념관 상세
+        </a>
+
+        {{-- Desktop Table --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hidden md:block">
+            <div class="p-6 pb-0">
+                <h3 class="text-base font-semibold text-[#2c2520] mb-4">{{ $memorial->name }}의 방명록 ({{ $comments->total() }})</h3>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-gray-50 border-b border-gray-100">
+                        <tr>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">ID</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">내용</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">작성자</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">노출</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">작성일</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($comments as $comment)
+                            <tr class="border-b border-gray-50 hover:bg-gray-50/50 transition">
+                                <td class="py-3 px-4 text-gray-400">{{ $comment->id }}</td>
+                                <td class="py-3 px-4 text-gray-900 max-w-xs truncate">{{ $comment->message }}</td>
+                                <td class="py-3 px-4 text-gray-500">{{ $comment->user->user_name ?? '-' }}</td>
+                                <td class="py-3 px-4">
+                                    @if($comment->is_visible)
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">노출</span>
+                                    @else
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">숨김</span>
+                                    @endif
+                                </td>
+                                <td class="py-3 px-4 text-gray-400">{{ $comment->created_at->format('Y-m-d') }}</td>
+                                <td class="py-3 px-4">
+                                    <div class="flex items-center gap-2" x-data="{ open: false }">
+                                        <button @click="open = true" class="text-[#c8952e] hover:underline text-sm">수정</button>
+                                        <form method="POST" action="{{ route('admin.memorials.comments.destroy', [$memorial->id, $comment->id]) }}"
+                                              onsubmit="return confirm('정말 이 방명록을 삭제하시겠습니까? 사용자가 직접 작성한 콘텐츠이므로 신중하게 처리해 주세요.')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                                        </form>
+
+                                        {{-- Edit Modal --}}
+                                        <div x-show="open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="open = false">
+                                            <div class="bg-white rounded-xl shadow-lg w-full max-w-lg mx-4 p-6" @click.stop>
+                                                <h3 class="text-base font-semibold text-[#2c2520] mb-4">방명록 수정</h3>
+                                                <form method="POST" action="{{ route('admin.memorials.comments.update', [$memorial->id, $comment->id]) }}"
+                                                      onsubmit="return confirm('방명록을 수정하시겠습니까? 사용자가 직접 작성한 콘텐츠입니다.')">
+                                                    @csrf
+                                                    @method('PATCH')
+                                                    <div>
+                                                        <label class="text-xs text-gray-500">내용</label>
+                                                        <textarea name="message" rows="6"
+                                                                  class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">{{ $comment->message }}</textarea>
+                                                    </div>
+                                                    <div class="flex justify-end gap-2 mt-6">
+                                                        <button type="button" @click="open = false" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</button>
+                                                        <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="6" class="py-8 text-center text-gray-400">방명록이 없습니다.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            @if($comments->hasPages())
+                <div class="px-4 py-3 border-t border-gray-100">
+                    {{ $comments->links() }}
+                </div>
+            @endif
+        </div>
+
+        {{-- Mobile Cards --}}
+        <div class="md:hidden">
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-3">
+                <h3 class="text-base font-semibold text-[#2c2520]">{{ $memorial->name }}의 방명록 ({{ $comments->total() }})</h3>
+            </div>
+
+            <div class="space-y-3">
+                @forelse($comments as $comment)
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4" x-data="{ open: false }">
+                        <div class="flex items-start justify-between mb-2">
+                            <span class="text-xs text-gray-400">#{{ $comment->id }}</span>
+                            @if($comment->is_visible)
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 ml-2 shrink-0">노출</span>
+                            @else
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 ml-2 shrink-0">숨김</span>
+                            @endif
+                        </div>
+                        <p class="text-sm text-gray-900 mb-2 line-clamp-3">{{ $comment->message }}</p>
+                        <div class="text-xs text-gray-500 mb-3">
+                            <span>{{ $comment->user->user_name ?? '-' }}</span>
+                            <span class="mx-1">&middot;</span>
+                            <span>{{ $comment->created_at->format('Y-m-d') }}</span>
+                        </div>
+                        <div class="flex items-center gap-3 pt-2 border-t border-gray-100">
+                            <button @click="open = true" class="text-[#c8952e] hover:underline text-sm font-medium">수정</button>
+                            <form method="POST" action="{{ route('admin.memorials.comments.destroy', [$memorial->id, $comment->id]) }}"
+                                  onsubmit="return confirm('정말 이 방명록을 삭제하시겠습니까? 사용자가 직접 작성한 콘텐츠이므로 신중하게 처리해 주세요.')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                            </form>
+                        </div>
+
+                        {{-- Edit Modal --}}
+                        <div x-show="open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="open = false">
+                            <div class="bg-white rounded-xl shadow-lg w-full max-w-lg mx-4 p-6" @click.stop>
+                                <h3 class="text-base font-semibold text-[#2c2520] mb-4">방명록 수정</h3>
+                                <form method="POST" action="{{ route('admin.memorials.comments.update', [$memorial->id, $comment->id]) }}"
+                                      onsubmit="return confirm('방명록을 수정하시겠습니까? 사용자가 직접 작성한 콘텐츠입니다.')">
+                                    @csrf
+                                    @method('PATCH')
+                                    <div>
+                                        <label class="text-xs text-gray-500">내용</label>
+                                        <textarea name="message" rows="6"
+                                                  class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">{{ $comment->message }}</textarea>
+                                    </div>
+                                    <div class="flex justify-end gap-2 mt-6">
+                                        <button type="button" @click="open = false" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</button>
+                                        <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">방명록이 없습니다.</div>
+                @endforelse
+            </div>
+
+            @if($comments->hasPages())
+                <div class="mt-4">
+                    {{ $comments->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/memorials/edit.blade.php
+++ b/resources/views/admin/memorials/edit.blade.php
@@ -1,0 +1,63 @@
+<x-admin-layout title="기념관 정보 수정">
+    <div>
+        {{-- Back --}}
+        <a href="{{ route('admin.memorials.show', $memorial->id) }}" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#c8952e] mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+            기념관 상세
+        </a>
+
+        {{-- Notice --}}
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex items-start gap-3">
+            <svg class="w-5 h-5 text-amber-500 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+            </svg>
+            <div class="text-sm text-amber-800">
+                <p class="font-medium">기념관 정보 변경 시 주의사항</p>
+                <p class="mt-1 text-amber-700">기념관은 사용자가 소중한 사람을 기리기 위해 직접 작성한 공간입니다. 변경 내용은 앱과 웹에 즉시 반영되므로 신중하게 처리해 주세요.</p>
+            </div>
+        </div>
+
+        {{-- Edit Form --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-4">기본 정보 수정</h3>
+            <form method="POST" action="{{ route('admin.memorials.update', $memorial->id) }}"
+                  onsubmit="return confirm('기념관 기본 정보를 변경하시겠습니까? 변경 내용이 앱과 웹에 즉시 반영됩니다.')">
+                @csrf
+                @method('PATCH')
+                <div class="space-y-4">
+                    <div>
+                        <label for="name" class="block text-xs font-medium text-gray-500 mb-1">기념관명</label>
+                        <input type="text" id="name" name="name" value="{{ old('name', $memorial->name) }}" maxlength="50"
+                               class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                        @error('name') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+                    <div class="grid grid-cols-2 gap-4">
+                        <div>
+                            <label for="birth_start" class="block text-xs font-medium text-gray-500 mb-1">출생</label>
+                            <input type="date" id="birth_start" name="birth_start" value="{{ old('birth_start', $memorial->birth_start) }}"
+                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                            @error('birth_start') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                        </div>
+                        <div>
+                            <label for="birth_end" class="block text-xs font-medium text-gray-500 mb-1">서거</label>
+                            <input type="date" id="birth_end" name="birth_end" value="{{ old('birth_end', $memorial->birth_end) }}"
+                                   class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                            @error('birth_end') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                        </div>
+                    </div>
+                    <div>
+                        <label for="career_contents" class="block text-xs font-medium text-gray-500 mb-1">생애</label>
+                        <textarea id="career_contents" name="career_contents" rows="20"
+                                  class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e] font-mono">{{ old('career_contents', $memorial->career_contents) }}</textarea>
+                        <p class="mt-1 text-xs text-gray-400">HTML, 마크다운, 일반 텍스트 모두 지원됩니다.</p>
+                        @error('career_contents') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+                </div>
+                <div class="flex gap-3 pt-6">
+                    <button type="submit" class="flex-1 sm:flex-none px-8 py-3 bg-[#c8952e] text-white rounded-lg text-base font-semibold hover:bg-[#b5852a] transition">저장</button>
+                    <a href="{{ route('admin.memorials.show', $memorial->id) }}" class="flex-1 sm:flex-none px-8 py-3 text-base text-center text-gray-600 hover:text-gray-800 border border-gray-300 rounded-lg font-medium transition">취소</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/memorials/index.blade.php
+++ b/resources/views/admin/memorials/index.blade.php
@@ -1,0 +1,101 @@
+<x-admin-layout title="기념관 관리">
+    {{-- Search --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-6">
+        <form method="GET" action="{{ route('admin.memorials.index') }}" class="flex gap-3">
+            <div class="flex-1">
+                <input type="text" name="search" value="{{ request('search') }}"
+                       placeholder="기념관명, 회원 검색..."
+                       class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+            </div>
+            <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">검색</button>
+        </form>
+    </div>
+
+    {{-- Desktop Table --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hidden md:block">
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead class="bg-gray-50 border-b border-gray-100">
+                    <tr>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">ID</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">기념관명</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">소유자</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">생년</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">공개여부</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">생성일</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($memorials as $memorial)
+                        <tr class="border-b border-gray-50 hover:bg-gray-50/50 transition">
+                            <td class="py-3 px-4 text-gray-400">{{ $memorial->id }}</td>
+                            <td class="py-3 px-4 font-medium text-gray-900">{{ $memorial->name }}</td>
+                            <td class="py-3 px-4 text-gray-500">{{ $memorial->user->user_name ?? '-' }} ({{ $memorial->user->user_id ?? '-' }})</td>
+                            <td class="py-3 px-4 text-gray-500">{{ $memorial->birth_start ?? '-' }}</td>
+                            <td class="py-3 px-4">
+                                @if($memorial->is_open)
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">공개</span>
+                                @else
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">비공개</span>
+                                @endif
+                            </td>
+                            <td class="py-3 px-4 text-gray-400">{{ $memorial->created_at->format('Y-m-d') }}</td>
+                            <td class="py-3 px-4">
+                                <div class="flex items-center gap-3">
+                                    <a href="{{ route('admin.memorials.show', $memorial->id) }}" class="text-[#c8952e] hover:underline text-sm">상세</a>
+                                    <a href="{{ route('admin.memorials.stories.index', $memorial->id) }}" class="text-gray-500 hover:text-[#c8952e] hover:underline text-sm">스토리</a>
+                                    <a href="{{ route('admin.memorials.comments.index', $memorial->id) }}" class="text-gray-500 hover:text-[#c8952e] hover:underline text-sm">방명록</a>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="7" class="py-8 text-center text-gray-400">기념관이 없습니다.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        @if($memorials->hasPages())
+            <div class="px-4 py-3 border-t border-gray-100">
+                {{ $memorials->links() }}
+            </div>
+        @endif
+    </div>
+
+    {{-- Mobile Cards --}}
+    <div class="md:hidden space-y-3">
+        @forelse($memorials as $memorial)
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+                <div class="flex items-start justify-between mb-2">
+                    <div>
+                        <span class="text-xs text-gray-400">#{{ $memorial->id }}</span>
+                        <h4 class="text-sm font-semibold text-gray-900">{{ $memorial->name }}</h4>
+                    </div>
+                    @if($memorial->is_open)
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">공개</span>
+                    @else
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">비공개</span>
+                    @endif
+                </div>
+                <div class="text-xs text-gray-500 space-y-1 mb-3">
+                    <p>소유자: {{ $memorial->user->user_name ?? '-' }} ({{ $memorial->user->user_id ?? '-' }})</p>
+                    <p>생년: {{ $memorial->birth_start ?? '-' }} · 생성일: {{ $memorial->created_at->format('Y-m-d') }}</p>
+                </div>
+                <div class="flex items-center gap-3 pt-2 border-t border-gray-100">
+                    <a href="{{ route('admin.memorials.show', $memorial->id) }}" class="text-[#c8952e] hover:underline text-sm font-medium">상세</a>
+                    <a href="{{ route('admin.memorials.stories.index', $memorial->id) }}" class="text-gray-500 hover:text-[#c8952e] hover:underline text-sm">스토리</a>
+                    <a href="{{ route('admin.memorials.comments.index', $memorial->id) }}" class="text-gray-500 hover:text-[#c8952e] hover:underline text-sm">방명록</a>
+                </div>
+            </div>
+        @empty
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">기념관이 없습니다.</div>
+        @endforelse
+
+        @if($memorials->hasPages())
+            <div class="mt-4">
+                {{ $memorials->links() }}
+            </div>
+        @endif
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/memorials/show.blade.php
+++ b/resources/views/admin/memorials/show.blade.php
@@ -1,0 +1,420 @@
+<x-admin-layout title="기념관 상세">
+    @push('head')
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link rel="stylesheet" href="https://fonts.bunny.net/css?family=gowun-dodum:400&family=ibm-plex-sans:400,700&display=swap">
+    @endpush
+    @php
+        // 콘텐츠 포맷 감지 (앱의 detectFormat 로직 동일)
+        $careerContents = $memorial->career_contents ?? '';
+        $contentFormat = 'text';
+        if ($careerContents) {
+            if (preg_match('/<[a-z][\s\S]*>/i', $careerContents)) {
+                $contentFormat = 'html';
+            } else {
+                $mdPatterns = ['/^#{1,6}\s/m', '/\*\*[^*]+\*\*/', '/^[-*]\s/m', '/^\d+\.\s/m', '/\[.+\]\(.+\)/', '/^>/m', '/^---$/m'];
+                $distinctCount = 0;
+                $hasRepeat = false;
+                foreach ($mdPatterns as $p) {
+                    $matches = preg_match_all($p, $careerContents);
+                    if ($matches > 0) {
+                        $distinctCount++;
+                        if ($matches >= 2) $hasRepeat = true;
+                    }
+                }
+                if ($distinctCount >= 2 || $hasRepeat) $contentFormat = 'markdown';
+            }
+        }
+    @endphp
+    <div>
+        <a href="{{ route('admin.memorials.index') }}" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#c8952e] mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+            기념관 목록
+        </a>
+
+        {{-- Notice --}}
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex items-start gap-3">
+            <svg class="w-5 h-5 text-amber-500 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+            </svg>
+            <div class="text-sm text-amber-800">
+                <p class="font-medium">기념관 정보 변경 시 주의사항</p>
+                <p class="mt-1 text-amber-700">기념관은 사용자가 소중한 사람을 기리기 위해 직접 작성한 공간입니다. 설정 변경 및 삭제 시 신중하게 처리해 주세요.</p>
+            </div>
+        </div>
+
+        {{-- Memorial Info (read-only) --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-5">기본 정보</h3>
+            <dl class="rounded-lg border border-gray-200 overflow-hidden">
+                {{-- Row 1: 기념관명 / 소유자 --}}
+                <div class="grid grid-cols-1 sm:grid-cols-2 border-b border-gray-200 bg-gray-50">
+                    <div class="px-4 py-3 sm:border-r sm:border-gray-200">
+                        <dt class="text-xs font-medium text-gray-500">기념관명</dt>
+                        <dd class="mt-1 text-sm font-semibold text-[#2c2520]">{{ $memorial->name }}</dd>
+                    </div>
+                    <div class="px-4 py-3 border-t sm:border-t-0 border-gray-200">
+                        <dt class="text-xs font-medium text-gray-500">소유자</dt>
+                        <dd class="mt-1 text-sm font-semibold text-[#2c2520]">
+                            @if($owner)
+                                <a href="{{ route('admin.users.show', $owner->id) }}" class="text-[#c8952e] hover:underline">
+                                    {{ $owner->user_name }} ({{ $owner->user_id }})
+                                </a>
+                            @else
+                                -
+                            @endif
+                        </dd>
+                    </div>
+                </div>
+                {{-- Row 2: 출생 / 서거 --}}
+                <div class="grid grid-cols-1 sm:grid-cols-2 border-b border-gray-200">
+                    <div class="px-4 py-3 sm:border-r sm:border-gray-200">
+                        <dt class="text-xs font-medium text-gray-500">출생</dt>
+                        <dd class="mt-1 text-sm font-semibold text-[#2c2520]">{{ $memorial->birth_start ?? '-' }}</dd>
+                    </div>
+                    <div class="px-4 py-3 border-t sm:border-t-0 border-gray-200">
+                        <dt class="text-xs font-medium text-gray-500">서거</dt>
+                        <dd class="mt-1 text-sm font-semibold text-[#2c2520]">{{ $memorial->birth_end ?? '-' }}</dd>
+                    </div>
+                </div>
+                {{-- Row 3: 생성일 / 공개 상태 --}}
+                <div class="grid grid-cols-1 sm:grid-cols-2 {{ $memorial->career_contents ? 'border-b border-gray-200' : '' }} bg-gray-50">
+                    <div class="px-4 py-3 sm:border-r sm:border-gray-200">
+                        <dt class="text-xs font-medium text-gray-500">생성일</dt>
+                        <dd class="mt-1 text-sm font-semibold text-[#2c2520]">{{ $memorial->created_at->format('Y-m-d H:i') }}</dd>
+                    </div>
+                    <div class="px-4 py-3 border-t sm:border-t-0 border-gray-200">
+                        <dt class="text-xs font-medium text-gray-500">공개 상태</dt>
+                        <dd class="mt-1">
+                            @if($memorial->is_open)
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">공개</span>
+                            @else
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-200 text-gray-600">비공개</span>
+                            @endif
+                        </dd>
+                    </div>
+                </div>
+                {{-- Row 4: 생애 --}}
+                @if($memorial->career_contents)
+                <div class="px-4 py-4">
+                    <dt class="text-xs font-medium text-gray-500 mb-2">생애</dt>
+                    <dd class="text-sm text-gray-700 leading-relaxed whitespace-pre-line">{{ $memorial->career_contents }}</dd>
+                    <div class="mt-3">
+                        <span class="format-label format-label--{{ $contentFormat }}">
+                            @if($contentFormat === 'html')
+                                <svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8v8h5v-4h6v4h5V8L8 0z"/></svg>
+                            @elseif($contentFormat === 'markdown')
+                                <svg viewBox="0 0 16 16" fill="currentColor"><path d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.7C0 12.48.52 13 1.15 13h13.7c.63 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"/></svg>
+                            @else
+                                <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2 3.75A.75.75 0 012.75 3h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 3.75zm0 4A.75.75 0 012.75 7h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 7.75zm0 4a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75z"/></svg>
+                            @endif
+                            Raw {{ strtoupper($contentFormat) }}
+                        </span>
+                    </div>
+                </div>
+                @endif
+            </dl>
+        </div>
+
+        {{-- Profile Image & BGM --}}
+        @if($memorial->attachmentProfileImage || $memorial->attachmentBgm)
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-4">미디어</h3>
+            <div class="flex flex-wrap items-start gap-6">
+                @if($memorial->attachmentProfileImage)
+                    <div>
+                        <p class="text-xs text-gray-500 mb-2">프로필 이미지</p>
+                        <img src="{{ $memorial->attachmentProfileImage->file_path }}" alt="프로필"
+                             class="w-24 h-24 object-cover rounded-lg">
+                    </div>
+                @endif
+                @if($memorial->attachmentBgm)
+                    <div class="flex-1 min-w-[200px]">
+                        <p class="text-xs text-gray-500 mb-2">배경음악</p>
+                        <audio controls class="w-full">
+                            <source src="{{ $memorial->attachmentBgm->file_path }}">
+                        </audio>
+                        <p class="text-xs text-gray-400 mt-1">{{ $memorial->attachmentBgm->file_name }}</p>
+                    </div>
+                @endif
+            </div>
+        </div>
+        @endif
+
+        {{-- Visibility Toggle --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-4">공개 설정</h3>
+            <form method="POST" action="{{ route('admin.memorials.update', $memorial->id) }}"
+                  onsubmit="return confirm('기념관 공개 설정을 변경하시겠습니까?')">
+                @csrf
+                @method('PATCH')
+                <label class="flex items-center gap-3">
+                    <input type="hidden" name="is_open" value="0">
+                    <input type="checkbox" name="is_open" value="1" {{ $memorial->is_open ? 'checked' : '' }}
+                           class="rounded border-gray-300 text-[#c8952e] focus:ring-[#c8952e]">
+                    <span class="text-sm text-gray-700">공개</span>
+                </label>
+                <div class="mt-4">
+                    <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                </div>
+            </form>
+        </div>
+
+        {{-- Edit & Delete --}}
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+                <h3 class="text-base font-semibold text-[#2c2520] mb-2">기념관 정보 수정</h3>
+                <p class="text-sm text-gray-500 mb-4">기념관명, 출생/서거일, 생애 등 기본 정보를 수정합니다.</p>
+                <a href="{{ route('admin.memorials.edit', $memorial->id) }}"
+                   class="inline-flex items-center gap-1 px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+                    정보 수정
+                </a>
+            </div>
+            <div class="bg-white rounded-xl shadow-sm border border-red-100 p-6">
+                <h3 class="text-base font-semibold text-red-600 mb-2">기념관 삭제</h3>
+                <p class="text-sm text-gray-500 mb-4">기념관을 삭제하면 관련 스토리, 방명록이 모두 함께 삭제되며 복구할 수 없습니다.</p>
+                <form method="POST" action="{{ route('admin.memorials.destroy', $memorial->id) }}"
+                      onsubmit="return confirm('정말 이 기념관을 삭제하시겠습니까? 스토리, 방명록이 모두 삭제됩니다.')">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 transition">기념관 삭제</button>
+                </form>
+            </div>
+        </div>
+
+        {{-- Stories & Comments Summary --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-4">콘텐츠</h3>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                    <div>
+                        <span class="text-sm text-gray-500">스토리</span>
+                        <span class="ml-2 text-lg font-semibold text-[#2c2520]">{{ $storyCount }}건</span>
+                    </div>
+                    <a href="{{ route('admin.memorials.stories.index', $memorial->id) }}" class="text-[#c8952e] hover:underline text-sm font-medium">관리 &rarr;</a>
+                </div>
+                <div class="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                    <div>
+                        <span class="text-sm text-gray-500">방명록</span>
+                        <span class="ml-2 text-lg font-semibold text-[#2c2520]">{{ $commentCount }}건</span>
+                    </div>
+                    <a href="{{ route('admin.memorials.comments.index', $memorial->id) }}" class="text-[#c8952e] hover:underline text-sm font-medium">관리 &rarr;</a>
+                </div>
+            </div>
+        </div>
+        {{-- Platform Previews --}}
+        <div class="mb-6">
+            <div class="flex items-center gap-2 mb-4">
+                <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+                <h3 class="text-base font-semibold text-[#2c2520]">플랫폼별 미리보기</h3>
+            </div>
+
+            @php
+                $profileUrl = $memorial->attachmentProfileImage?->file_path;
+                $birthStart = $memorial->birth_start ? date('Y.m.d', strtotime($memorial->birth_start)) : '';
+                $birthEnd = $memorial->birth_end ? date('Y.m.d', strtotime($memorial->birth_end)) : '';
+                $lifespanText = '';
+                if ($birthStart && $birthEnd) $lifespanText = "{$birthStart} ~ {$birthEnd}";
+                elseif ($birthStart) $lifespanText = "{$birthStart} ~";
+                elseif ($birthEnd) $lifespanText = "~ {$birthEnd}";
+
+            @endphp
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+                {{-- Web (PC) Preview --}}
+                <div>
+                    <div class="flex items-center gap-2 mb-3">
+                        <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                        <span class="text-sm font-medium text-gray-500">웹 (PC)</span>
+                    </div>
+                    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-md">
+                        {{-- Browser Chrome --}}
+                        <div class="bg-gray-100 border-b border-gray-200 px-4 py-2 flex items-center gap-2">
+                            <div class="flex gap-1.5">
+                                <div class="w-3 h-3 rounded-full bg-red-400"></div>
+                                <div class="w-3 h-3 rounded-full bg-yellow-400"></div>
+                                <div class="w-3 h-3 rounded-full bg-green-400"></div>
+                            </div>
+                            <div class="flex-1 bg-white rounded px-3 py-1 text-xs text-gray-400 ml-2 truncate">yourmemorial.kr/detail/{{ $memorial->id }}</div>
+                        </div>
+
+                        {{-- Web Header --}}
+                        <div class="bg-white border-b border-[#ececee] px-4 py-2 flex items-center gap-2" style="font-family: 'Gowun Dodum', sans-serif;">
+                            <img src="https://yourmemorial.kr/logo.svg" alt="Logo" class="w-5 h-5" onerror="this.style.display='none'">
+                            <span class="text-sm font-semibold text-black">메모리얼</span>
+                        </div>
+
+                        {{-- Background Image --}}
+                        <div style="height: 180px;">
+                            <div class="w-full h-full bg-cover bg-center" style="background-image: url('https://yourmemorial.kr/form-top-bg.jpeg');"></div>
+                        </div>
+
+                        {{-- Profile --}}
+                        <div class="flex justify-center -mt-12 relative z-10">
+                            @if($profileUrl)
+                                <img src="{{ $profileUrl }}" alt="프로필" class="w-24 h-24 object-cover rounded-lg shadow-lg bg-gray-200">
+                            @else
+                                <div class="w-24 h-24 rounded-lg bg-gray-200 shadow-lg flex items-center justify-center">
+                                    <svg class="w-10 h-10 text-gray-400" fill="currentColor" viewBox="0 0 24 24"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
+                                </div>
+                            @endif
+                        </div>
+
+                        {{-- Name & Lifespan --}}
+                        <div class="text-center py-5" style="font-family: 'Gowun Dodum', sans-serif;">
+                            <h2 class="text-2xl font-bold text-black">{{ $memorial->name }}</h2>
+                            @if($lifespanText)
+                                <p class="text-base text-black/70 mt-1">{{ $lifespanText }}</p>
+                            @endif
+                        </div>
+
+                        {{-- Tabs & Bio (same width container) --}}
+                        <div class="mx-auto" style="width: 70%; font-family: 'IBM Plex Sans', sans-serif;">
+                            {{-- Tabs --}}
+                            <div class="flex justify-center gap-4 mb-4" style="border-radius: 12px;">
+                                <div class="text-center py-2 px-3 text-sm font-bold rounded-lg" style="width: 80%; background-color: #000; color: #fff; box-shadow: 0px 4px 6px rgba(0,0,0,0.2);">생애<br><span style="font-weight: normal; font-size: 0.75rem;">Life</span></div>
+                                <div class="text-center py-2 px-3 text-sm font-bold rounded-lg" style="width: 80%; background-color: #f3f3f3; color: #000; box-shadow: 0px 4px 6px rgba(0,0,0,0.2);">기억들<br><span style="font-weight: normal; font-size: 0.75rem;">Memories</span></div>
+                            </div>
+
+                            {{-- Bio (포맷별 렌더링) --}}
+                            <div style="margin-top: 2rem;">
+                                <div style="background-color: rgb(247 247 247 / 95%); border-radius: 4px; padding: 1rem;">
+                                    @if($contentFormat === 'html')
+                                        <div class="web-bio-html" style="font-size: 0.875rem; line-height: 1.5; color: #000; white-space: pre-wrap; word-wrap: break-word;">{!! $careerContents !!}</div>
+                                    @elseif($contentFormat === 'markdown')
+                                        <div id="web-bio-markdown" class="web-bio-md" style="font-size: 0.875rem; line-height: 1.5; color: #000; word-wrap: break-word;"></div>
+                                    @else
+                                        <div style="font-size: 0.875rem; line-height: 1.5; color: #000; white-space: pre-wrap; word-wrap: break-word;">{{ $careerContents ?: '(내용 없음)' }}</div>
+                                    @endif
+                                </div>
+                                <div style="margin-top: 8px;">
+                                    <span class="format-label format-label--{{ $contentFormat }}">
+                                        @if($contentFormat === 'html')
+                                            <svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8v8h5v-4h6v4h5V8L8 0z"/></svg>
+                                        @elseif($contentFormat === 'markdown')
+                                            <svg viewBox="0 0 16 16" fill="currentColor"><path d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.7C0 12.48.52 13 1.15 13h13.7c.63 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"/></svg>
+                                        @else
+                                            <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2 3.75A.75.75 0 012.75 3h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 3.75zm0 4A.75.75 0 012.75 7h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 7.75zm0 4a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75z"/></svg>
+                                        @endif
+                                        {{ strtoupper($contentFormat) }}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div style="height: 2rem;"></div>
+                    </div>
+                </div>
+
+                {{-- App Preview --}}
+                <div>
+                    <div class="flex items-center gap-2 mb-3">
+                        <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg>
+                        <span class="text-sm font-medium text-gray-500">앱</span>
+                    </div>
+                    <div class="mx-auto" style="max-width: 375px;">
+                        <div class="bg-[#faf8f5] rounded-[2rem] border-[3px] border-gray-800 overflow-hidden shadow-xl" style="min-height: 580px;">
+                            {{-- Status Bar --}}
+                            <div class="bg-gray-800 text-white text-center text-xs py-1.5 font-medium">미리보기</div>
+
+                            {{-- Profile Header --}}
+                            <div class="relative">
+                                <div class="h-[140px] bg-cover bg-center" style="background-image: url('https://yourmemorial.kr/form-top-bg.jpeg');">
+                                    <div class="absolute inset-0 bg-black/15"></div>
+                                </div>
+                                <div class="flex flex-col items-center -mt-[50px] relative z-10 pb-4">
+                                    @if($profileUrl)
+                                        <img src="{{ $profileUrl }}" alt="프로필" class="w-[100px] h-[100px] rounded-full border-[3px] border-white object-cover shadow-lg bg-gray-200">
+                                    @else
+                                        <div class="w-[100px] h-[100px] rounded-full border-[3px] border-white bg-gray-200 shadow-lg flex items-center justify-center">
+                                            <svg class="w-10 h-10 text-gray-400" fill="currentColor" viewBox="0 0 24 24"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
+                                        </div>
+                                    @endif
+                                    <h2 class="mt-3 text-xl font-bold text-[#2c2520] text-center">{{ $memorial->name }}</h2>
+                                    @if($lifespanText)
+                                        <p class="text-sm text-gray-500 mt-1 text-center">{{ $lifespanText }}</p>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- Tab Bar --}}
+                            <div class="flex border-b border-gray-200 px-4">
+                                <div class="flex-1 text-center py-2.5 text-sm font-semibold text-[#c8952e] border-b-2 border-[#c8952e]">생애</div>
+                                <div class="flex-1 text-center py-2.5 text-sm text-gray-400">기억들</div>
+                            </div>
+
+                            {{-- Bio (앱 detectFormat 로직 적용) --}}
+                            <div class="px-4 py-4">
+                                <h3 class="text-base font-bold text-[#2c2520] mb-3">생애</h3>
+                                @if($contentFormat === 'html')
+                                    <div class="app-bio-html" style="color: #2c2520; font-size: 15px; line-height: 26px; word-wrap: break-word;">{!! $careerContents !!}</div>
+                                @elseif($contentFormat === 'markdown')
+                                    <div id="app-bio-markdown" class="app-bio-md" style="color: #2c2520; font-size: 15px; line-height: 26px; word-wrap: break-word;"></div>
+                                @else
+                                    <div style="color: #2c2520; font-size: 15px; line-height: 26px; white-space: pre-line; word-wrap: break-word;">{{ $careerContents ?: '(내용 없음)' }}</div>
+                                @endif
+                                <div class="mt-2">
+                                    <span class="format-label format-label--{{ $contentFormat }}">
+                                        @if($contentFormat === 'html')
+                                            <svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8v8h5v-4h6v4h5V8L8 0z"/></svg>
+                                        @elseif($contentFormat === 'markdown')
+                                            <svg viewBox="0 0 16 16" fill="currentColor"><path d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.7C0 12.48.52 13 1.15 13h13.7c.63 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7V8L5.5 9.92 4 8v3H2V5h2l1.5 2L7 5h2v6zm2.99.5L9.5 8H11V5h2v3h1.5l-2.51 3.5z"/></svg>
+                                        @else
+                                            <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2 3.75A.75.75 0 012.75 3h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 3.75zm0 4A.75.75 0 012.75 7h10.5a.75.75 0 010 1.5H2.75A.75.75 0 012 7.75zm0 4a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75z"/></svg>
+                                        @endif
+                                        {{ strtoupper($contentFormat) }}
+                                    </span>
+                                </div>
+                            </div>
+                            <div style="height: 2rem;"></div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+            <p class="text-center text-xs text-gray-400 mt-3">미리보기는 실제 화면의 근사치입니다.</p>
+        </div>
+    </div>
+
+    {{-- GitHub 스타일 라벨 + 앱 미리보기 스타일 --}}
+    <style>
+        .format-label { display: inline-flex; align-items: center; gap: 4px; padding: 2px 10px; font-size: 12px; font-weight: 500; line-height: 22px; border-radius: 9999px; white-space: nowrap; }
+        .format-label svg { width: 12px; height: 12px; }
+        .format-label--html { background-color: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; }
+        .format-label--markdown { background-color: #faf5ff; color: #7e22ce; border: 1px solid #e9d5ff; }
+        .format-label--text { background-color: #f9fafb; color: #4b5563; border: 1px solid #e5e7eb; }
+        .app-bio-html p { margin-top: 0; margin-bottom: 8px; }
+        .app-bio-html a { color: #c8952e; }
+        .app-bio-md h2 { font-size: 18px; font-weight: 700; color: #2c2520; margin-top: 16px; margin-bottom: 8px; }
+        .app-bio-md h3 { font-size: 16px; font-weight: 600; color: #2c2520; margin-top: 12px; margin-bottom: 6px; }
+        .app-bio-md p { margin-top: 0; margin-bottom: 8px; }
+        .app-bio-md strong { font-weight: 700; }
+        .app-bio-md a { color: #c8952e; }
+        .app-bio-md hr { background-color: #e5e5e5; height: 1px; border: none; margin: 12px 0; }
+        .app-bio-md blockquote { background-color: #f5f5f5; border-left: 3px solid #c8952e; padding: 4px 12px; margin: 8px 0; }
+        .web-bio-html p { margin-top: 0; margin-bottom: 8px; }
+        .web-bio-md h2 { font-size: 1rem; font-weight: 700; margin-top: 16px; margin-bottom: 8px; }
+        .web-bio-md h3 { font-size: 0.9375rem; font-weight: 600; margin-top: 12px; margin-bottom: 6px; }
+        .web-bio-md p { margin-top: 0; margin-bottom: 8px; }
+        .web-bio-md strong { font-weight: 700; }
+        .web-bio-md a { color: #c8952e; }
+        .web-bio-md hr { background-color: #e5e5e5; height: 1px; border: none; margin: 12px 0; }
+        .web-bio-md blockquote { background-color: #f0f0f0; border-left: 3px solid #999; padding: 4px 12px; margin: 8px 0; }
+    </style>
+
+    @if($contentFormat === 'markdown')
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var raw = @json($careerContents);
+            var webEl = document.getElementById('web-bio-markdown');
+            var appEl = document.getElementById('app-bio-markdown');
+            if (typeof marked !== 'undefined') {
+                if (webEl) webEl.innerHTML = marked.parse(raw);
+                if (appEl) appEl.innerHTML = marked.parse(raw);
+            }
+        });
+    </script>
+    @endif
+</x-admin-layout>

--- a/resources/views/admin/memorials/stories.blade.php
+++ b/resources/views/admin/memorials/stories.blade.php
@@ -1,0 +1,168 @@
+<x-admin-layout title="{{ $memorial->name }}의 스토리">
+    <div>
+        <a href="{{ route('admin.memorials.show', $memorial->id) }}" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#c8952e] mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+            기념관 상세
+        </a>
+
+        {{-- Desktop Table --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hidden md:block">
+            <div class="p-6 pb-0">
+                <h3 class="text-base font-semibold text-[#2c2520] mb-4">{{ $memorial->name }}의 스토리 ({{ $stories->total() }})</h3>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-gray-50 border-b border-gray-100">
+                        <tr>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">ID</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">제목</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">작성자</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">노출</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium">작성일</th>
+                            <th class="text-left py-3 px-4 text-gray-500 font-medium"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($stories as $story)
+                            <tr class="border-b border-gray-50 hover:bg-gray-50/50 transition">
+                                <td class="py-3 px-4 text-gray-400">{{ $story->id }}</td>
+                                <td class="py-3 px-4 font-medium text-gray-900 max-w-xs truncate">{{ $story->title ?? '-' }}</td>
+                                <td class="py-3 px-4 text-gray-500">{{ $story->user->user_name ?? '-' }}</td>
+                                <td class="py-3 px-4">
+                                    @if($story->is_visible)
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">노출</span>
+                                    @else
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">숨김</span>
+                                    @endif
+                                </td>
+                                <td class="py-3 px-4 text-gray-400">{{ $story->created_at->format('Y-m-d') }}</td>
+                                <td class="py-3 px-4">
+                                    <div class="flex items-center gap-2" x-data="{ open: false }">
+                                        <button @click="open = true" class="text-[#c8952e] hover:underline text-sm">수정</button>
+                                        <form method="POST" action="{{ route('admin.memorials.stories.destroy', [$memorial->id, $story->id]) }}"
+                                              onsubmit="return confirm('정말 이 스토리를 삭제하시겠습니까? 사용자가 직접 작성한 콘텐츠이므로 신중하게 처리해 주세요.')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                                        </form>
+
+                                        {{-- Edit Modal --}}
+                                        <div x-show="open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="open = false">
+                                            <div class="bg-white rounded-xl shadow-lg w-full max-w-lg mx-4 p-6" @click.stop>
+                                                <h3 class="text-base font-semibold text-[#2c2520] mb-4">스토리 수정</h3>
+                                                <form method="POST" action="{{ route('admin.memorials.stories.update', [$memorial->id, $story->id]) }}"
+                                                      onsubmit="return confirm('스토리를 수정하시겠습니까? 사용자가 직접 작성한 콘텐츠입니다.')">
+                                                    @csrf
+                                                    @method('PATCH')
+                                                    <div class="space-y-4">
+                                                        <div>
+                                                            <label class="text-xs text-gray-500">제목</label>
+                                                            <input type="text" name="title" value="{{ $story->title }}"
+                                                                   class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                                                        </div>
+                                                        <div>
+                                                            <label class="text-xs text-gray-500">내용</label>
+                                                            <textarea name="message" rows="6"
+                                                                      class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">{{ $story->message }}</textarea>
+                                                        </div>
+                                                    </div>
+                                                    <div class="flex justify-end gap-2 mt-6">
+                                                        <button type="button" @click="open = false" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</button>
+                                                        <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="6" class="py-8 text-center text-gray-400">스토리가 없습니다.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            @if($stories->hasPages())
+                <div class="px-4 py-3 border-t border-gray-100">
+                    {{ $stories->links() }}
+                </div>
+            @endif
+        </div>
+
+        {{-- Mobile Cards --}}
+        <div class="md:hidden">
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-3">
+                <h3 class="text-base font-semibold text-[#2c2520]">{{ $memorial->name }}의 스토리 ({{ $stories->total() }})</h3>
+            </div>
+
+            <div class="space-y-3">
+                @forelse($stories as $story)
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4" x-data="{ open: false }">
+                        <div class="flex items-start justify-between mb-2">
+                            <div class="flex-1 min-w-0">
+                                <span class="text-xs text-gray-400">#{{ $story->id }}</span>
+                                <h4 class="text-sm font-semibold text-gray-900 truncate">{{ $story->title ?? '-' }}</h4>
+                            </div>
+                            @if($story->is_visible)
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 ml-2 shrink-0">노출</span>
+                            @else
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 ml-2 shrink-0">숨김</span>
+                            @endif
+                        </div>
+                        <div class="text-xs text-gray-500 mb-3">
+                            <span>{{ $story->user->user_name ?? '-' }}</span>
+                            <span class="mx-1">&middot;</span>
+                            <span>{{ $story->created_at->format('Y-m-d') }}</span>
+                        </div>
+                        <div class="flex items-center gap-3 pt-2 border-t border-gray-100">
+                            <button @click="open = true" class="text-[#c8952e] hover:underline text-sm font-medium">수정</button>
+                            <form method="POST" action="{{ route('admin.memorials.stories.destroy', [$memorial->id, $story->id]) }}"
+                                  onsubmit="return confirm('정말 이 스토리를 삭제하시겠습니까? 사용자가 직접 작성한 콘텐츠이므로 신중하게 처리해 주세요.')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                            </form>
+                        </div>
+
+                        {{-- Edit Modal --}}
+                        <div x-show="open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="open = false">
+                            <div class="bg-white rounded-xl shadow-lg w-full max-w-lg mx-4 p-6" @click.stop>
+                                <h3 class="text-base font-semibold text-[#2c2520] mb-4">스토리 수정</h3>
+                                <form method="POST" action="{{ route('admin.memorials.stories.update', [$memorial->id, $story->id]) }}"
+                                      onsubmit="return confirm('스토리를 수정하시겠습니까? 사용자가 직접 작성한 콘텐츠입니다.')">
+                                    @csrf
+                                    @method('PATCH')
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label class="text-xs text-gray-500">제목</label>
+                                            <input type="text" name="title" value="{{ $story->title }}"
+                                                   class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                                        </div>
+                                        <div>
+                                            <label class="text-xs text-gray-500">내용</label>
+                                            <textarea name="message" rows="6"
+                                                      class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">{{ $story->message }}</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="flex justify-end gap-2 mt-6">
+                                        <button type="button" @click="open = false" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</button>
+                                        <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">스토리가 없습니다.</div>
+                @endforelse
+            </div>
+
+            @if($stories->hasPages())
+                <div class="mt-4">
+                    {{ $stories->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/purchases/index.blade.php
+++ b/resources/views/admin/purchases/index.blade.php
@@ -1,0 +1,190 @@
+<x-admin-layout title="구매 신청 관리">
+    {{-- Filter --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-6">
+        <form method="GET" action="{{ route('admin.purchases.index') }}" class="flex gap-3">
+            <select name="status" class="border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                <option value="">전체</option>
+                <option value="pending" {{ request('status') === 'pending' ? 'selected' : '' }}>대기</option>
+                <option value="approved" {{ request('status') === 'approved' ? 'selected' : '' }}>승인</option>
+                <option value="rejected" {{ request('status') === 'rejected' ? 'selected' : '' }}>거절</option>
+            </select>
+            <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">필터</button>
+        </form>
+    </div>
+
+    {{-- Desktop Table --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hidden md:block">
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead class="bg-gray-50 border-b border-gray-100">
+                    <tr>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">ID</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">회원</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">상태</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">메모</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">신청일</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">처리일</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">처리</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($purchases as $purchase)
+                        <tr class="border-b border-gray-50 hover:bg-gray-50/50 transition" x-data="{ open: false }">
+                            <td class="py-3 px-4 text-gray-400">{{ $purchase->id }}</td>
+                            <td class="py-3 px-4">
+                                @if($purchase->user)
+                                    <a href="{{ route('admin.users.show', $purchase->user->id) }}" class="text-[#c8952e] hover:underline">
+                                        {{ $purchase->user->user_name }} ({{ $purchase->user->user_id }})
+                                    </a>
+                                @else
+                                    <span class="text-gray-400">-</span>
+                                @endif
+                            </td>
+                            <td class="py-3 px-4">
+                                @if($purchase->status === 'pending')
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">대기</span>
+                                @elseif($purchase->status === 'approved')
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">승인</span>
+                                @else
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">거절</span>
+                                @endif
+                            </td>
+                            <td class="py-3 px-4 text-gray-500 max-w-xs truncate">{{ $purchase->admin_memo ?? '-' }}</td>
+                            <td class="py-3 px-4 text-gray-400">{{ $purchase->created_at->format('Y-m-d H:i') }}</td>
+                            <td class="py-3 px-4 text-gray-400">{{ $purchase->processed_at ? \Carbon\Carbon::parse($purchase->processed_at)->format('Y-m-d H:i') : '-' }}</td>
+                            <td class="py-3 px-4">
+                                <div class="flex items-center gap-2">
+                                <button @click="open = !open" class="text-[#c8952e] hover:underline text-sm">처리</button>
+                                <form method="POST" action="{{ route('admin.purchases.destroy', $purchase->id) }}"
+                                      onsubmit="return confirm('정말 삭제하시겠습니까?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                                </form>
+                                <div x-show="open" x-cloak @click.away="open = false" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+                                    <div class="bg-white rounded-xl shadow-xl p-6 w-full max-w-md mx-4" @click.stop>
+                                        <h3 class="text-base font-semibold text-[#2c2520] mb-4">구매 신청 처리</h3>
+                                        <form method="POST" action="{{ route('admin.purchases.updateStatus', $purchase->id) }}">
+                                            @csrf
+                                            @method('PATCH')
+                                            <div class="mb-4">
+                                                <label class="block text-sm text-gray-700 mb-1">상태</label>
+                                                <select name="status" class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                                                    <option value="pending" {{ $purchase->status === 'pending' ? 'selected' : '' }}>대기</option>
+                                                    <option value="approved" {{ $purchase->status === 'approved' ? 'selected' : '' }}>승인</option>
+                                                    <option value="rejected" {{ $purchase->status === 'rejected' ? 'selected' : '' }}>거절</option>
+                                                </select>
+                                            </div>
+                                            <div class="mb-4">
+                                                <label class="block text-sm text-gray-700 mb-1">관리자 메모</label>
+                                                <textarea name="admin_memo" rows="3"
+                                                    class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]"
+                                                    placeholder="메모 입력...">{{ $purchase->admin_memo }}</textarea>
+                                            </div>
+                                            <div class="flex justify-end gap-2">
+                                                <button type="button" @click="open = false" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</button>
+                                                <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="7" class="py-8 text-center text-gray-400">구매 신청이 없습니다.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        @if($purchases->hasPages())
+            <div class="px-4 py-3 border-t border-gray-100">
+                {{ $purchases->links() }}
+            </div>
+        @endif
+    </div>
+
+    {{-- Mobile Cards --}}
+    <div class="md:hidden space-y-3">
+        @forelse($purchases as $purchase)
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4" x-data="{ open: false }">
+                <div class="flex items-start justify-between mb-2">
+                    <div>
+                        <span class="text-xs text-gray-400">#{{ $purchase->id }}</span>
+                        @if($purchase->user)
+                            <h4 class="text-sm font-semibold text-gray-900">
+                                <a href="{{ route('admin.users.show', $purchase->user->id) }}" class="text-[#c8952e] hover:underline">
+                                    {{ $purchase->user->user_name }} ({{ $purchase->user->user_id }})
+                                </a>
+                            </h4>
+                        @else
+                            <h4 class="text-sm text-gray-400">-</h4>
+                        @endif
+                    </div>
+                    @if($purchase->status === 'pending')
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 shrink-0 ml-2">대기</span>
+                    @elseif($purchase->status === 'approved')
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 shrink-0 ml-2">승인</span>
+                    @else
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 shrink-0 ml-2">거절</span>
+                    @endif
+                </div>
+                @if($purchase->admin_memo)
+                    <p class="text-xs text-gray-500 mb-2 line-clamp-2">{{ $purchase->admin_memo }}</p>
+                @endif
+                <div class="text-xs text-gray-400 mb-3">
+                    <span>신청: {{ $purchase->created_at->format('Y-m-d H:i') }}</span>
+                    @if($purchase->processed_at)
+                        <span class="mx-1">·</span>
+                        <span>처리: {{ \Carbon\Carbon::parse($purchase->processed_at)->format('Y-m-d H:i') }}</span>
+                    @endif
+                </div>
+                <div class="flex items-center gap-3 pt-2 border-t border-gray-100">
+                    <button @click="open = !open" class="text-[#c8952e] hover:underline text-sm font-medium">처리</button>
+                    <form method="POST" action="{{ route('admin.purchases.destroy', $purchase->id) }}"
+                          onsubmit="return confirm('정말 삭제하시겠습니까?')">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                    </form>
+                    <div x-show="open" x-cloak @click.away="open = false" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+                        <div class="bg-white rounded-xl shadow-xl p-6 w-full max-w-md mx-4" @click.stop>
+                            <h3 class="text-base font-semibold text-[#2c2520] mb-4">구매 신청 처리</h3>
+                            <form method="POST" action="{{ route('admin.purchases.updateStatus', $purchase->id) }}">
+                                @csrf
+                                @method('PATCH')
+                                <div class="mb-4">
+                                    <label class="block text-sm text-gray-700 mb-1">상태</label>
+                                    <select name="status" class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                                        <option value="pending" {{ $purchase->status === 'pending' ? 'selected' : '' }}>대기</option>
+                                        <option value="approved" {{ $purchase->status === 'approved' ? 'selected' : '' }}>승인</option>
+                                        <option value="rejected" {{ $purchase->status === 'rejected' ? 'selected' : '' }}>거절</option>
+                                    </select>
+                                </div>
+                                <div class="mb-4">
+                                    <label class="block text-sm text-gray-700 mb-1">관리자 메모</label>
+                                    <textarea name="admin_memo" rows="3"
+                                        class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]"
+                                        placeholder="메모 입력...">{{ $purchase->admin_memo }}</textarea>
+                                </div>
+                                <div class="flex justify-end gap-2">
+                                    <button type="button" @click="open = false" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</button>
+                                    <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">구매 신청이 없습니다.</div>
+        @endforelse
+
+        @if($purchases->hasPages())
+            <div class="mt-4">
+                {{ $purchases->links() }}
+            </div>
+        @endif
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/questions/edit.blade.php
+++ b/resources/views/admin/questions/edit.blade.php
@@ -1,0 +1,75 @@
+<x-admin-layout title="{{ $question ? '질문 수정' : '질문 추가' }}">
+    <div>
+        <a href="{{ route('admin.questions.index') }}" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#c8952e] mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+            질문 목록
+        </a>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <form method="POST"
+                  action="{{ $question ? route('admin.questions.update', $question->id) : route('admin.questions.store') }}">
+                @csrf
+                @if($question) @method('PUT') @endif
+
+                <div class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">질문 타입</label>
+                        <select name="question_type"
+                                class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                            @foreach(['name' => '이름', 'birth_start' => '생년', 'question' => '질문', 'profile' => '프로필'] as $value => $label)
+                                <option value="{{ $value }}" {{ old('question_type', $detail->question_type ?? '') === $value ? 'selected' : '' }}>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('question_type')
+                            <p class="text-sm text-red-600 mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">질문 내용</label>
+                        <textarea name="question_title" rows="3"
+                                  class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]"
+                                  placeholder="질문을 입력하세요...">{{ old('question_title', $detail->question_title ?? '') }}</textarea>
+                        @error('question_title')
+                            <p class="text-sm text-red-600 mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">표시 순서</label>
+                        @if($question && in_array($question->display_order, [1, 2]))
+                            <input type="number" value="{{ $question->display_order }}" disabled
+                                   class="w-full border-gray-300 rounded-lg text-sm bg-gray-100 text-gray-500">
+                            <p class="text-xs text-gray-400 mt-1">필수 질문은 순서를 변경할 수 없습니다.</p>
+                        @else
+                            <input type="number" name="display_order" min="3"
+                                   value="{{ old('display_order', $question->display_order ?? 0) }}"
+                                   class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                            @error('display_order')
+                                <p class="text-sm text-red-600 mt-1">{{ $message }}</p>
+                            @enderror
+                        @endif
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">활성화</label>
+                        <select name="is_active"
+                                class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                            <option value="1" {{ old('is_active', $question->is_active ?? 1) == 1 ? 'selected' : '' }}>활성</option>
+                            <option value="0" {{ old('is_active', $question->is_active ?? 1) == 0 ? 'selected' : '' }}>비활성</option>
+                        </select>
+                    </div>
+
+                    <div class="flex gap-2 pt-2">
+                        <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">
+                            {{ $question ? '수정' : '추가' }}
+                        </button>
+                        <a href="{{ route('admin.questions.index') }}" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">취소</a>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/questions/index.blade.php
+++ b/resources/views/admin/questions/index.blade.php
@@ -1,0 +1,110 @@
+<x-admin-layout title="질문 관리">
+    {{-- Header --}}
+    <div class="flex items-center justify-between mb-4">
+        <p class="text-sm text-gray-500">AI 자서전 생성에 사용되는 질문을 관리합니다.</p>
+        <a href="{{ route('admin.questions.create') }}"
+           class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition shrink-0 ml-3">
+            질문 추가
+        </a>
+    </div>
+    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex items-start gap-3">
+        <svg class="w-5 h-5 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        <div>
+            <p class="text-sm font-medium text-amber-800 mb-1">필수 질문 안내</p>
+            <p class="text-sm text-amber-700">1, 2번 질문은 필수이며 순서가 고정됩니다. 순서 변경 및 삭제는 3번 이후 질문만 가능합니다.</p>
+        </div>
+    </div>
+
+    {{-- Desktop Table --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hidden md:block">
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead class="bg-gray-50 border-b border-gray-100">
+                    <tr>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">순서</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">타입</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">질문</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">활성화</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">관리</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($questions as $question)
+                        <tr class="border-b border-gray-50 hover:bg-gray-50/50 transition">
+                            <td class="py-3 px-4 text-gray-400">{{ $question->display_order }}</td>
+                            <td class="py-3 px-4">
+                                <span class="px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                                    {{ $question->detail->question_type ?? '-' }}
+                                </span>
+                            </td>
+                            <td class="py-3 px-4 font-medium text-gray-900">{{ $question->detail->question_title ?? '-' }}</td>
+                            <td class="py-3 px-4">
+                                @if($question->is_active)
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">활성</span>
+                                @else
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">비활성</span>
+                                @endif
+                            </td>
+                            <td class="py-3 px-4">
+                                <div class="flex items-center gap-2">
+                                    <a href="{{ route('admin.questions.edit', $question->id) }}" class="text-[#c8952e] hover:underline text-sm">수정</a>
+                                    @if(!in_array($question->display_order, [1, 2]))
+                                        <form method="POST" action="{{ route('admin.questions.destroy', $question->id) }}"
+                                              onsubmit="return confirm('정말 삭제하시겠습니까?')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                                        </form>
+                                    @else
+                                        <span class="text-xs text-gray-400">필수</span>
+                                    @endif
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="5" class="py-8 text-center text-gray-400">등록된 질문이 없습니다.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    {{-- Mobile Cards --}}
+    <div class="md:hidden space-y-3">
+        @forelse($questions as $question)
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+                <div class="flex items-start justify-between mb-2">
+                    <div class="flex items-center gap-2">
+                        <span class="text-xs text-gray-400">{{ $question->display_order }}번</span>
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                            {{ $question->detail->question_type ?? '-' }}
+                        </span>
+                    </div>
+                    @if($question->is_active)
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 shrink-0 ml-2">활성</span>
+                    @else
+                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 shrink-0 ml-2">비활성</span>
+                    @endif
+                </div>
+                <p class="text-sm font-medium text-gray-900 mb-3">{{ $question->detail->question_title ?? '-' }}</p>
+                <div class="flex items-center gap-3 pt-2 border-t border-gray-100">
+                    <a href="{{ route('admin.questions.edit', $question->id) }}" class="text-[#c8952e] hover:underline text-sm font-medium">수정</a>
+                    @if(!in_array($question->display_order, [1, 2]))
+                        <form method="POST" action="{{ route('admin.questions.destroy', $question->id) }}"
+                              onsubmit="return confirm('정말 삭제하시겠습니까?')">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-red-500 hover:underline text-sm">삭제</button>
+                        </form>
+                    @else
+                        <span class="text-xs text-gray-400">필수</span>
+                    @endif
+                </div>
+            </div>
+        @empty
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">등록된 질문이 없습니다.</div>
+        @endforelse
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,0 +1,130 @@
+<x-admin-layout title="회원 관리">
+    {{-- Search & Filter --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-6">
+        <form method="GET" action="{{ route('admin.users.index') }}" class="flex flex-col sm:flex-row gap-3">
+            <div class="flex-1">
+                <input type="text" name="search" value="{{ request('search') }}"
+                       placeholder="아이디, 이름, 이메일 검색..."
+                       class="w-full border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+            </div>
+            <select name="filter" class="border-gray-300 rounded-lg text-sm focus:border-[#c8952e] focus:ring-[#c8952e]">
+                <option value="">전체</option>
+                <option value="admin" {{ request('filter') === 'admin' ? 'selected' : '' }}>관리자</option>
+                <option value="normal" {{ request('filter') === 'normal' ? 'selected' : '' }}>일반</option>
+                <option value="trial" {{ request('filter') === 'trial' ? 'selected' : '' }}>체험판</option>
+                <option value="dormancy" {{ request('filter') === 'dormancy' ? 'selected' : '' }}>휴면</option>
+                <option value="withdraw" {{ request('filter') === 'withdraw' ? 'selected' : '' }}>탈퇴</option>
+            </select>
+            <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">검색</button>
+        </form>
+    </div>
+
+    {{-- Desktop Table --}}
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hidden md:block">
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead class="bg-gray-50 border-b border-gray-100">
+                    <tr>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">ID</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">아이디</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">이름</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">이메일</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">타입</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">상태</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium">가입일</th>
+                        <th class="text-left py-3 px-4 text-gray-500 font-medium"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($users as $user)
+                        <tr class="border-b border-gray-50 hover:bg-gray-50/50 transition">
+                            <td class="py-3 px-4 text-gray-400">{{ $user->id }}</td>
+                            <td class="py-3 px-4 font-medium text-gray-900">{{ $user->user_id }}</td>
+                            <td class="py-3 px-4">{{ $user->user_name }}</td>
+                            <td class="py-3 px-4 text-gray-500">{{ $user->email }}</td>
+                            <td class="py-3 px-4">
+                                @if($user->is_admin)
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-[#c8952e]/10 text-[#c8952e]">관리자</span>
+                                @else
+                                    <span class="px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700">일반</span>
+                                @endif
+                            </td>
+                            <td class="py-3 px-4">
+                                <div class="flex flex-wrap gap-1">
+                                    @if($user->is_trial)
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">체험판</span>
+                                    @endif
+                                    @if($user->is_dormancy)
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">휴면</span>
+                                    @endif
+                                    @if($user->is_withdraw)
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">탈퇴</span>
+                                    @endif
+                                    @if(!$user->is_trial && !$user->is_dormancy && !$user->is_withdraw)
+                                        <span class="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">정상</span>
+                                    @endif
+                                </div>
+                            </td>
+                            <td class="py-3 px-4 text-gray-400">{{ $user->created_at->format('Y-m-d') }}</td>
+                            <td class="py-3 px-4">
+                                <a href="{{ route('admin.users.show', $user->id) }}" class="text-[#c8952e] hover:underline text-sm">상세</a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="8" class="py-8 text-center text-gray-400">회원이 없습니다.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        @if($users->hasPages())
+            <div class="px-4 py-3 border-t border-gray-100">
+                {{ $users->links() }}
+            </div>
+        @endif
+    </div>
+
+    {{-- Mobile Cards --}}
+    <div class="md:hidden space-y-3">
+        @forelse($users as $user)
+            <a href="{{ route('admin.users.show', $user->id) }}" class="block bg-white rounded-xl shadow-sm border border-gray-100 p-4 active:bg-gray-50 transition">
+                <div class="flex items-start justify-between mb-2">
+                    <div class="min-w-0 flex-1">
+                        <span class="text-xs text-gray-400">#{{ $user->id }}</span>
+                        <h4 class="text-sm font-semibold text-gray-900">{{ $user->user_name }}</h4>
+                        <p class="text-xs text-gray-500">{{ $user->user_id }}</p>
+                    </div>
+                    <div class="flex flex-col items-end gap-1 ml-3 shrink-0">
+                        @if($user->is_admin)
+                            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-[#c8952e]/10 text-[#c8952e] leading-normal">관리자</span>
+                        @else
+                            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 leading-normal">일반</span>
+                        @endif
+                        @if($user->is_trial)
+                            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 leading-normal">체험판</span>
+                        @elseif($user->is_dormancy)
+                            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 leading-normal">휴면</span>
+                        @elseif($user->is_withdraw)
+                            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 leading-normal">탈퇴</span>
+                        @else
+                            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 leading-normal">정상</span>
+                        @endif
+                    </div>
+                </div>
+                <div class="text-xs text-gray-500">
+                    <span>{{ $user->email }}</span>
+                    <span class="mx-1">·</span>
+                    <span>{{ $user->created_at->format('Y-m-d') }}</span>
+                </div>
+            </a>
+        @empty
+            <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center text-gray-400">회원이 없습니다.</div>
+        @endforelse
+
+        @if($users->hasPages())
+            <div class="mt-4">
+                {{ $users->links() }}
+            </div>
+        @endif
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -1,0 +1,128 @@
+<x-admin-layout title="회원 상세">
+    <div>
+        {{-- Back --}}
+        <a href="{{ route('admin.users.index') }}" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#c8952e] mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+            회원 목록
+        </a>
+
+        {{-- Notice --}}
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex items-start gap-3">
+            <svg class="w-5 h-5 text-amber-500 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+            </svg>
+            <div class="text-sm text-amber-800">
+                <p class="font-medium">개인정보 변경 시 주의사항</p>
+                <p class="mt-1 text-amber-700">이름, 아이디, 이메일은 사용자가 직접 입력한 중요 개인정보입니다. 변경 시 사용자의 로그인 및 서비스 이용에 영향을 줄 수 있으므로 신중하게 처리해 주세요.</p>
+            </div>
+        </div>
+
+        {{-- User Info (editable) --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-4">기본 정보</h3>
+            <form method="POST" action="{{ route('admin.users.update', $user->id) }}"
+                  onsubmit="return confirm('회원의 기본 정보를 변경하시겠습니까? 로그인 및 서비스 이용에 영향을 줄 수 있습니다.')">
+                @csrf
+                @method('PATCH')
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                        <label class="text-xs text-gray-500">ID</label>
+                        <p class="mt-1 text-sm font-medium text-gray-900">{{ $user->id }}</p>
+                    </div>
+                    <div>
+                        <label for="user_id" class="text-xs text-gray-500">아이디</label>
+                        <input type="text" id="user_id" name="user_id" value="{{ old('user_id', $user->user_id) }}"
+                               class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                        @error('user_id') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label for="user_name" class="text-xs text-gray-500">이름</label>
+                        <input type="text" id="user_name" name="user_name" value="{{ old('user_name', $user->user_name) }}"
+                               class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                        @error('user_name') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label for="email" class="text-xs text-gray-500">이메일</label>
+                        <input type="email" id="email" name="email" value="{{ old('email', $user->email) }}"
+                               class="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#c8952e]/50 focus:border-[#c8952e]">
+                        @error('email') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+                    <div>
+                        <label class="text-xs text-gray-500">연락처</label>
+                        <p class="mt-1 text-sm font-medium text-gray-900 py-2">{{ $user->user_phone ?? '-' }}</p>
+                    </div>
+                    <div>
+                        <label class="text-xs text-gray-500">가입일</label>
+                        <p class="mt-1 text-sm font-medium text-gray-900 py-2">{{ $user->created_at->format('Y-m-d H:i') }}</p>
+                    </div>
+                    <div>
+                        <label class="text-xs text-gray-500">최근 로그인</label>
+                        <p class="mt-1 text-sm font-medium text-gray-900 py-2">{{ $user->last_login_time ?? '-' }}</p>
+                    </div>
+                    <div>
+                        <label class="text-xs text-gray-500">기념관</label>
+                        <p class="mt-1 text-sm font-medium text-gray-900 py-2">
+                            @if($user->memorial)
+                                <a href="{{ route('admin.memorials.show', $user->memorial->id) }}" class="text-[#c8952e] hover:underline">
+                                    {{ $user->memorial->name }}
+                                </a>
+                            @else
+                                -
+                            @endif
+                        </p>
+                    </div>
+                </div>
+                <div class="pt-4">
+                    <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">기본 정보 저장</button>
+                </div>
+            </form>
+        </div>
+
+        {{-- Status Management --}}
+        <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+            <h3 class="text-base font-semibold text-[#2c2520] mb-4">상태 관리</h3>
+            <form method="POST" action="{{ route('admin.users.update', $user->id) }}"
+                  onsubmit="return confirm('회원 상태를 변경하시겠습니까?')">
+                @csrf
+                @method('PATCH')
+                <div class="space-y-4">
+                    <label class="flex items-center gap-3">
+                        <input type="hidden" name="is_admin" value="0">
+                        <input type="checkbox" name="is_admin" value="1" {{ $user->is_admin ? 'checked' : '' }}
+                               class="rounded border-gray-300 text-[#c8952e] focus:ring-[#c8952e]">
+                        <span class="text-sm text-gray-700">관리자 권한</span>
+                    </label>
+                    <label class="flex items-center gap-3">
+                        <input type="hidden" name="is_dormancy" value="0">
+                        <input type="checkbox" name="is_dormancy" value="1" {{ $user->is_dormancy ? 'checked' : '' }}
+                               class="rounded border-gray-300 text-[#c8952e] focus:ring-[#c8952e]">
+                        <span class="text-sm text-gray-700">휴면 처리</span>
+                    </label>
+                    <label class="flex items-center gap-3">
+                        <input type="hidden" name="is_withdraw" value="0">
+                        <input type="checkbox" name="is_withdraw" value="1" {{ $user->is_withdraw ? 'checked' : '' }}
+                               class="rounded border-gray-300 text-[#c8952e] focus:ring-[#c8952e]">
+                        <span class="text-sm text-gray-700">탈퇴 처리</span>
+                    </label>
+                    <div class="pt-2">
+                        <button type="submit" class="px-4 py-2 bg-[#c8952e] text-white rounded-lg text-sm font-medium hover:bg-[#b5852a] transition">저장</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        {{-- Delete --}}
+        @if($user->user_id !== 'admin')
+            <div class="bg-white rounded-xl shadow-sm border border-red-100 p-6">
+                <h3 class="text-base font-semibold text-red-600 mb-2">회원 삭제</h3>
+                <p class="text-sm text-gray-500 mb-4">회원을 삭제하면 관련 기념관, 스토리, 방명록이 모두 함께 삭제되며 복구할 수 없습니다.</p>
+                <form method="POST" action="{{ route('admin.users.destroy', $user->id) }}"
+                      onsubmit="return confirm('정말 이 회원을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.')">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 transition">회원 삭제</button>
+                </form>
+            </div>
+        @endif
+    </div>
+</x-admin-layout>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,47 +1,49 @@
 <x-guest-layout>
+    <div class="text-center mb-6">
+        <div class="w-12 h-12 rounded-full bg-[#c8952e] flex items-center justify-center mx-auto mb-3">
+            <svg class="w-7 h-7 text-white" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 2a1 1 0 011 1v1.323l3.954 1.582 1.599-.8a1 1 0 01.894 1.79l-1.233.616 1.738 5.42a1 1 0 01-.285 1.05A3.989 3.989 0 0115 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.715-5.349L10 6.2V16h3a1 1 0 110 2H7a1 1 0 110-2h3V6.2L6.237 7.582l1.715 5.349a1 1 0 01-.285 1.05A3.989 3.989 0 015 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.738-5.42-1.233-.617a1 1 0 01.894-1.788l1.599.799L9 4.323V3a1 1 0 011-1z"/>
+            </svg>
+        </div>
+        <h2 class="text-lg font-bold text-[#2c2520]">메모리얼 Admin</h2>
+        <p class="text-sm text-gray-500 mt-1">관리자 로그인</p>
+    </div>
+
     <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
 
     <form method="POST" action="{{ route('login') }}">
         @csrf
 
-        <!-- Email Address -->
+        <!-- User ID -->
         <div>
-            <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+            <x-input-label for="user_id" :value="__('아이디')" />
+            <x-text-input id="user_id" class="block mt-1 w-full" type="text" name="user_id" :value="old('user_id')" required autofocus autocomplete="username" />
+            <x-input-error :messages="$errors->get('user_id')" class="mt-2" />
         </div>
 
         <!-- Password -->
         <div class="mt-4">
-            <x-input-label for="password" :value="__('Password')" />
-
+            <x-input-label for="password" :value="__('비밀번호')" />
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
                             name="password"
                             required autocomplete="current-password" />
-
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
 
         <!-- Remember Me -->
         <div class="block mt-4">
             <label for="remember_me" class="inline-flex items-center">
-                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
-                <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
+                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-[#c8952e] shadow-sm focus:ring-[#c8952e]" name="remember">
+                <span class="ml-2 text-sm text-gray-600">로그인 유지</span>
             </label>
         </div>
 
-        <div class="flex items-center justify-end mt-4">
-            @if (Route::has('password.request'))
-                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('password.request') }}">
-                    {{ __('Forgot your password?') }}
-                </a>
-            @endif
-
-            <x-primary-button class="ml-3">
-                {{ __('Log in') }}
-            </x-primary-button>
+        <div class="mt-6">
+            <button type="submit" class="w-full px-4 py-2.5 bg-[#c8952e] text-white rounded-lg text-sm font-semibold hover:bg-[#b5852a] focus:outline-none focus:ring-2 focus:ring-[#c8952e] focus:ring-offset-2 transition">
+                로그인
+            </button>
         </div>
     </form>
 </x-guest-layout>

--- a/resources/views/components/admin-layout.blade.php
+++ b/resources/views/components/admin-layout.blade.php
@@ -1,0 +1,75 @@
+@props(['title' => '관리자'])
+
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ $title }} - 메모리얼 Admin</title>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <style>[x-cloak] { display: none !important; }</style>
+    @stack('head')
+</head>
+<body class="font-sans antialiased bg-[#faf8f5]">
+    <div class="min-h-screen flex">
+        {{-- Sidebar --}}
+        @include('admin.layouts.navigation')
+
+        {{-- Main Content --}}
+        <div class="flex-1 lg:ml-64">
+            {{-- Top Bar --}}
+            <header class="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-10">
+                <div class="flex items-center justify-between px-6 py-4">
+                    <div class="flex items-center gap-3">
+                        <button onclick="document.getElementById('sidebar').classList.toggle('-translate-x-full')" class="lg:hidden text-gray-500 hover:text-gray-700">
+                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+                            </svg>
+                        </button>
+                        <h1 class="text-lg font-semibold text-[#2c2520]">{{ $title }}</h1>
+                    </div>
+                    <div class="flex items-center gap-4">
+                        <span class="text-sm text-gray-600">{{ Auth::user()->user_name }}</span>
+                        <form method="POST" action="{{ route('logout') }}">
+                            @csrf
+                            <button type="submit" class="text-sm text-gray-500 hover:text-[#c8952e] transition">로그아웃</button>
+                        </form>
+                    </div>
+                </div>
+            </header>
+
+            {{-- Page Content --}}
+            <main class="p-6">
+                @if(session('success'))
+                    <div class="mb-4 p-4 bg-green-50 border border-green-200 text-green-700 rounded-lg">
+                        {{ session('success') }}
+                    </div>
+                @endif
+                @if(session('error'))
+                    <div class="mb-4 p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg">
+                        {{ session('error') }}
+                    </div>
+                @endif
+
+                {{ $slot }}
+            </main>
+        </div>
+    </div>
+    <script>
+    document.addEventListener('submit', function(e) {
+        if (e.defaultPrevented) return;
+        var form = e.target;
+        if (!form || form.method === 'get') return;
+        var btn = e.submitter || form.querySelector('button[type="submit"]');
+        if (!btn || btn.disabled) return;
+        btn.disabled = true;
+        btn.classList.add('opacity-75', 'cursor-not-allowed');
+        var spinner = '<svg class="animate-spin inline-block w-4 h-4 align-middle" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>';
+        btn.innerHTML = spinner + ' ' + btn.textContent.trim();
+    });
+    </script>
+</body>
+</html>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,16 +15,23 @@
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans text-gray-900 antialiased">
-        <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
-            <div>
-                <a href="/">
-                    <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-                </a>
-            </div>
-
-            <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
+        <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-[#faf8f5]">
+            <div class="w-full sm:max-w-md mt-6 px-6 py-8 bg-white shadow-md overflow-hidden sm:rounded-xl">
                 {{ $slot }}
             </div>
         </div>
+        <script>
+        document.addEventListener('submit', function(e) {
+            if (e.defaultPrevented) return;
+            var form = e.target;
+            if (!form || form.method === 'get') return;
+            var btn = e.submitter || form.querySelector('button[type="submit"]');
+            if (!btn || btn.disabled) return;
+            btn.disabled = true;
+            btn.classList.add('opacity-75', 'cursor-not-allowed');
+            var spinner = '<svg class="animate-spin inline-block w-4 h-4 align-middle" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>';
+            btn.innerHTML = spinner + ' ' + btn.textContent.trim();
+        });
+        </script>
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,26 +1,60 @@
 <?php
 
+use App\Http\Controllers\Admin\AdminLogController;
+use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\MemorialController;
+use App\Http\Controllers\Admin\StoryController;
+use App\Http\Controllers\Admin\CommentController;
+use App\Http\Controllers\Admin\PurchaseRequestController;
+use App\Http\Controllers\Admin\QuestionController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider and all of them will
-| be assigned to the "web" middleware group. Make something great!
-|
-*/
-
 Route::get('/', function () {
-    return view('welcome');
+    return redirect('/login');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+// Admin Routes
+Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
+
+    // Users
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+    Route::get('/users/{id}', [UserController::class, 'show'])->name('users.show');
+    Route::patch('/users/{id}', [UserController::class, 'update'])->name('users.update');
+    Route::delete('/users/{id}', [UserController::class, 'destroy'])->name('users.destroy');
+
+    // Memorials
+    Route::get('/memorials', [MemorialController::class, 'index'])->name('memorials.index');
+    Route::get('/memorials/{id}', [MemorialController::class, 'show'])->name('memorials.show');
+    Route::get('/memorials/{id}/edit', [MemorialController::class, 'edit'])->name('memorials.edit');
+    Route::patch('/memorials/{id}', [MemorialController::class, 'update'])->name('memorials.update');
+    Route::delete('/memorials/{id}', [MemorialController::class, 'destroy'])->name('memorials.destroy');
+
+    // Stories (under memorials)
+    Route::get('/memorials/{id}/stories', [StoryController::class, 'index'])->name('memorials.stories.index');
+    Route::patch('/memorials/{id}/stories/{storyId}/toggle', [StoryController::class, 'toggle'])->name('memorials.stories.toggle');
+    Route::patch('/memorials/{id}/stories/{storyId}', [StoryController::class, 'update'])->name('memorials.stories.update');
+    Route::delete('/memorials/{id}/stories/{storyId}', [StoryController::class, 'destroy'])->name('memorials.stories.destroy');
+
+    // Comments (under memorials)
+    Route::get('/memorials/{id}/comments', [CommentController::class, 'index'])->name('memorials.comments.index');
+    Route::patch('/memorials/{id}/comments/{commentId}/toggle', [CommentController::class, 'toggle'])->name('memorials.comments.toggle');
+    Route::patch('/memorials/{id}/comments/{commentId}', [CommentController::class, 'update'])->name('memorials.comments.update');
+    Route::delete('/memorials/{id}/comments/{commentId}', [CommentController::class, 'destroy'])->name('memorials.comments.destroy');
+
+    // Purchase Requests
+    Route::get('/purchases', [PurchaseRequestController::class, 'index'])->name('purchases.index');
+    Route::patch('/purchases/{id}/status', [PurchaseRequestController::class, 'updateStatus'])->name('purchases.updateStatus');
+    Route::delete('/purchases/{id}', [PurchaseRequestController::class, 'destroy'])->name('purchases.destroy');
+
+    // Questions
+    Route::resource('/questions', QuestionController::class)->except(['show']);
+
+    // Admin Logs
+    Route::get('/logs', [AdminLogController::class, 'index'])->name('logs.index');
+});
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## 배경
기념관 서비스 운영을 위해 관리자 전용 어드민 패널이 필요합니다.
회원, 기념관, 구매요청, AI 질문 등 핵심 데이터를 관리하고, 관리자의 모든 행위를 활동 로그로 추적할 수 있어야 합니다.

## 작업내용

### 1. 어드민 인증 및 인프라 (`f31fe4c`)
- `EnsureIsAdmin` 미들웨어 — `is_admin` 플래그 기반 접근 제어
- 로그인 방식 email → user_id 변경 (일반 유저 로그인 차단)
- 어드민 전용 레이아웃 (Tailwind + Alpine.js, 반응형 사이드바)
- 폼 중복 제출 방지 글로벌 스피너
- `is_admin` 컬럼 마이그레이션 + `AdminUserSeeder`
- nginx `server_name`에 admin 도메인 추가

### 2. 어드민 관리 페이지 (`7fc8eca`)
- **대시보드**: 회원/기념관/구매요청 통계
- **회원관리**: 목록(검색/필터), 상세(정보수정/삭제)
- **기념관관리**: 목록, 상세(웹/앱 미리보기, 포맷별 렌더링), 수정, 삭제
- **스토리/방명록**: 목록, 수정(모달), 삭제
- **구매요청**: 목록, 상태변경(대기→완료→거절), 삭제
- **AI 질문**: CRUD (목록, 생성, 수정, 삭제)
- **활동 로그**: 관리자 행위 기록 + 대상별 필터 (회원/기념관/구매요청/AI질문)
- 모든 페이지 반응형 (데스크톱 테이블 + 모바일 카드)
- Eloquent relationship 기반 리팩토링 (raw JOIN 제거)

### 3. DB 성능 개선 (`098d4bb`)
- FK 인덱스 추가: `mm_memorials.user_id`, `mm_stories.memorial_id/user_id`, `mm_visitor_comments.memorial_id/user_id`, `mm_purchase_requests.user_id`

## 테스트방법
1. `php artisan db:seed --class=AdminUserSeeder`로 어드민 계정 생성
2. `/login`에서 어드민 user_id로 로그인 → 대시보드 진입 확인
3. 일반 유저 계정으로 로그인 시도 → 차단 확인
4. 각 관리 메뉴(회원, 기념관, 구매요청, AI 질문) CRUD 동작 확인
5. 데이터 수정/삭제 후 활동 로그 페이지에서 기록 확인
6. 활동 로그 필터(회원/기념관/구매요청/AI질문) 동작 확인
7. 모바일 화면에서 반응형 레이아웃 확인

## 리뷰노트
- 커밋이 기능별로 분리되어 있으므로 **커밋 단위로 리뷰**하시면 수월합니다
- 신규 파일 29개, 수정 파일 13개로 변경량이 많지만 대부분 Blade 뷰 파일입니다
- 스토리/방명록의 노출 토글(숨김/노출) 기능은 의도적으로 제외했습니다 (사용자 콘텐츠이므로 수정/삭제만 제공)
- 활동 로그 필터에서 스토리/방명록은 기념관에 포함하여 분류합니다
- Tailwind CSS 동적 클래스 purge 이슈로 활동 로그 라벨은 inline style을 사용합니다

### 운영 배포 후 필수 액션
머지 후 운영 서버에서 아래 순서대로 실행해주세요.

```bash
# 1. 코드 pull
git pull origin master

# 2. Composer 의존성 업데이트
composer install --no-dev --optimize-autoloader

# 3. 마이그레이션 실행 (4개 신규 테이블/컬럼)
php artisan migrate

# 4. 어드민 계정 생성
php artisan db:seed --class=AdminUserSeeder

# 5. 프론트엔드 에셋 빌드 (Tailwind + Alpine.js)
npm install && npm run build

# 6. 캐시 갱신
php artisan optimize

# 7. nginx 설정 반영 (server_name 변경)
sudo nginx -t && sudo systemctl reload nginx
```