### PR TITLE
TrustProxies 로드밸런서 신뢰 설정 추가

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
## 배경
AWS ALB 뒤에서 Laravel이 HTTPS를 인식하지 못해 에셋 URL과 로그인 후 리다이렉트가 HTTP로 생성되는 문제가 있었습니다.

## 작업내용
- `TrustProxies` 미들웨어의 `$proxies`를 `'*'`로 설정하여 모든 프록시(ALB)를 신뢰하도록 변경

## 테스트방법
1. `https://admin.yourmemorial.kr/login` 접속 → CSS/JS 정상 로드 확인
2. 로그인 후 HTTPS 유지 확인

## 리뷰노트
- 운영 서버에는 이미 적용하여 정상 동작 확인 완료