### PR TITLE
API 도메인 루트 접근 차단

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,11 @@ use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
-    return redirect('/login');
+    if (request()->getHost() === 'admin.yourmemorial.kr') {
+        return redirect('/login');
+    }
+
+    abort(403);
 });
 
 // Admin Routes


### PR DESCRIPTION
## 배경
`api.yourmemorial.kr`로 접속해도 어드민 로그인 페이지가 노출되는 문제가 있었습니다.

## 작업내용
- 루트(`/`) 경로에서 도메인 분기 처리
  - `admin.yourmemorial.kr` → 로그인 페이지로 리다이렉트
  - 그 외 도메인 → 403 Forbidden 응답

## 테스트방법
1. `admin.yourmemorial.kr` 접속 → 로그인 페이지 정상 이동 확인
2. `api.yourmemorial.kr` 접속 → 403 응답 확인
3. `api.yourmemorial.kr/api/*` API 호출 → 정상 동작 확인

## 리뷰노트
- 루트 경로만 차단하며 `/api/*` 하위 API 기능에는 영향 없음